### PR TITLE
Add master role and permission management screens

### DIFF
--- a/app/Http/Controllers/Master/PermissionController.php
+++ b/app/Http/Controllers/Master/PermissionController.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace App\Http\Controllers\Master;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Master\StorePermissionRequest;
+use App\Http\Requests\Master\UpdatePermissionRequest;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Routing\Controllers\HasMiddleware;
+use Illuminate\Routing\Controllers\Middleware;
+use Inertia\Inertia;
+use Inertia\Response;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
+
+class PermissionController extends Controller implements HasMiddleware
+{
+    /**
+     * Permissions that should not be removed from the system.
+     *
+     * @var array<int, string>
+     */
+    private const PROTECTED_PERMISSIONS = ['manage roles', 'manage permissions'];
+
+    /**
+     * Get the middleware that should be assigned to the controller.
+     */
+    public static function middleware(): array
+    {
+        return [new Middleware('can:manage permissions')];
+    }
+
+    /**
+     * Display the permission management screen.
+     */
+    public function index(): Response
+    {
+        $permissions = Permission::query()
+            ->withCount('roles')
+            ->orderBy('name')
+            ->get()
+            ->map(static function (Permission $permission): array {
+                return [
+                    'id' => $permission->id,
+                    'name' => $permission->name,
+                    'roles_count' => $permission->roles_count,
+                    'is_protected' => in_array($permission->name, self::PROTECTED_PERMISSIONS, true),
+                ];
+            });
+
+        return Inertia::render('master/permissions/index', [
+            'permissions' => $permissions,
+        ]);
+    }
+
+    /**
+     * Store a newly created permission in storage.
+     */
+    public function store(StorePermissionRequest $request): RedirectResponse
+    {
+        $permission = Permission::query()->create([
+            'name' => $request->string('name')->toString(),
+            'guard_name' => 'web',
+        ]);
+
+        $administrator = Role::query()->where('name', 'Administrator')->first();
+
+        if ($administrator !== null) {
+            $administrator->givePermissionTo($permission);
+        }
+
+        return back()->with('success', 'Permission created successfully.');
+    }
+
+    /**
+     * Update the specified permission in storage.
+     */
+    public function update(UpdatePermissionRequest $request, Permission $permission): RedirectResponse
+    {
+        $permission->update([
+            'name' => $request->string('name')->toString(),
+        ]);
+
+        return back()->with('success', 'Permission updated successfully.');
+    }
+
+    /**
+     * Remove the specified permission from storage.
+     */
+    public function destroy(Permission $permission): RedirectResponse
+    {
+        if (in_array($permission->name, self::PROTECTED_PERMISSIONS, true)) {
+            return back()->with('error', 'This permission cannot be deleted.');
+        }
+
+        if ($permission->roles()->exists()) {
+            return back()->with('error', 'Remove this permission from all roles before deleting it.');
+        }
+
+        $permission->delete();
+
+        return back()->with('success', 'Permission deleted successfully.');
+    }
+}
+

--- a/app/Http/Controllers/Master/RoleController.php
+++ b/app/Http/Controllers/Master/RoleController.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace App\Http\Controllers\Master;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Master\StoreRoleRequest;
+use App\Http\Requests\Master\UpdateRoleRequest;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Routing\Controllers\HasMiddleware;
+use Illuminate\Routing\Controllers\Middleware;
+use Inertia\Inertia;
+use Inertia\Response;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
+
+class RoleController extends Controller implements HasMiddleware
+{
+    /**
+     * Roles that cannot be removed from the system.
+     *
+     * @var array<int, string>
+     */
+    private const PROTECTED_ROLES = ['Administrator'];
+
+    /**
+     * Get the middleware that should be assigned to the controller.
+     */
+    public static function middleware(): array
+    {
+        return [new Middleware('can:manage roles')];
+    }
+
+    /**
+     * Display the role management screen.
+     */
+    public function index(): Response
+    {
+        $roles = Role::query()
+            ->with(['permissions:id,name'])
+            ->withCount('users')
+            ->orderBy('name')
+            ->get()
+            ->map(static function (Role $role): array {
+                return [
+                    'id' => $role->id,
+                    'name' => $role->name,
+                    'users_count' => $role->users_count,
+                    'permissions' => $role->permissions
+                        ->map(static fn (Permission $permission) => [
+                            'id' => $permission->id,
+                            'name' => $permission->name,
+                        ])
+                        ->values()
+                        ->all(),
+                    'is_protected' => in_array($role->name, self::PROTECTED_ROLES, true),
+                ];
+            });
+
+        $permissions = Permission::query()
+            ->orderBy('name')
+            ->get(['id', 'name'])
+            ->map(static fn (Permission $permission) => [
+                'id' => $permission->id,
+                'name' => $permission->name,
+            ]);
+
+        return Inertia::render('master/roles/index', [
+            'roles' => $roles,
+            'permissions' => $permissions,
+        ]);
+    }
+
+    /**
+     * Store a newly created role in storage.
+     */
+    public function store(StoreRoleRequest $request): RedirectResponse
+    {
+        $role = Role::query()->create([
+            'name' => $request->string('name')->toString(),
+            'guard_name' => 'web',
+        ]);
+
+        $role->syncPermissions($this->permissionIds($request->input('permissions', [])));
+
+        return back()->with('success', 'Role created successfully.');
+    }
+
+    /**
+     * Update the specified role in storage.
+     */
+    public function update(UpdateRoleRequest $request, Role $role): RedirectResponse
+    {
+        $role->update([
+            'name' => $request->string('name')->toString(),
+        ]);
+
+        $role->syncPermissions($this->permissionIds($request->input('permissions', [])));
+
+        return back()->with('success', 'Role updated successfully.');
+    }
+
+    /**
+     * Remove the specified role from storage.
+     */
+    public function destroy(Role $role): RedirectResponse
+    {
+        if (in_array($role->name, self::PROTECTED_ROLES, true)) {
+            return back()->with('error', 'The Administrator role cannot be deleted.');
+        }
+
+        $role->delete();
+
+        return back()->with('success', 'Role deleted successfully.');
+    }
+
+    /**
+     * Normalise permission IDs from the request payload.
+     *
+     * @param  array<int, int|string>  $permissions
+     * @return array<int, int>
+     */
+    private function permissionIds(array $permissions): array
+    {
+        return collect($permissions)
+            ->map(static fn ($permission) => (int) $permission)
+            ->filter()
+            ->values()
+            ->all();
+    }
+}
+

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -46,6 +46,10 @@ class HandleInertiaRequests extends Middleware
                 'user' => $request->user(),
             ],
             'sidebarOpen' => ! $request->hasCookie('sidebar_state') || $request->cookie('sidebar_state') === 'true',
+            'flash' => [
+                'success' => $request->session()->get('success'),
+                'error' => $request->session()->get('error'),
+            ],
         ];
     }
 }

--- a/app/Http/Requests/Master/StorePermissionRequest.php
+++ b/app/Http/Requests/Master/StorePermissionRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Requests\Master;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class StorePermissionRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, array<int, mixed>>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => ['required', 'string', 'max:255', Rule::unique('permissions', 'name')],
+        ];
+    }
+}
+

--- a/app/Http/Requests/Master/StoreRoleRequest.php
+++ b/app/Http/Requests/Master/StoreRoleRequest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Requests\Master;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class StoreRoleRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, array<int, mixed>>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => ['required', 'string', 'max:255', Rule::unique('roles', 'name')],
+            'permissions' => ['array'],
+            'permissions.*' => ['integer', 'exists:permissions,id'],
+        ];
+    }
+}
+

--- a/app/Http/Requests/Master/UpdatePermissionRequest.php
+++ b/app/Http/Requests/Master/UpdatePermissionRequest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Http\Requests\Master;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class UpdatePermissionRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, array<int, mixed>>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => [
+                'required',
+                'string',
+                'max:255',
+                Rule::unique('permissions', 'name')->ignore($this->route('permission')),
+            ],
+        ];
+    }
+}
+

--- a/app/Http/Requests/Master/UpdateRoleRequest.php
+++ b/app/Http/Requests/Master/UpdateRoleRequest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Requests\Master;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class UpdateRoleRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, array<int, mixed>>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => [
+                'required',
+                'string',
+                'max:255',
+                Rule::unique('roles', 'name')->ignore($this->route('role')),
+            ],
+            'permissions' => ['array'],
+            'permissions.*' => ['integer', 'exists:permissions,id'],
+        ];
+    }
+}
+

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -7,11 +7,12 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Laravel\Fortify\TwoFactorAuthenticatable;
+use Spatie\Permission\Traits\HasRoles;
 
 class User extends Authenticatable
 {
     /** @use HasFactory<\Database\Factories\UserFactory> */
-    use HasFactory, Notifiable, TwoFactorAuthenticatable;
+    use HasFactory, Notifiable, TwoFactorAuthenticatable, HasRoles;
 
     /**
      * The attributes that are mass assignable.

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -6,6 +6,8 @@ use App\Models\User;
 // use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\Hash;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
 
 class DatabaseSeeder extends Seeder
 {
@@ -16,7 +18,7 @@ class DatabaseSeeder extends Seeder
     {
         // User::factory(10)->create();
 
-        User::firstOrCreate(
+        $user = User::firstOrCreate(
             ['email' => 'test@example.com'],
             [
                 'name' => 'Test User',
@@ -24,5 +26,26 @@ class DatabaseSeeder extends Seeder
                 'email_verified_at' => now(),
             ]
         );
+
+        collect([
+            'manage roles',
+            'manage permissions',
+        ])->each(static function (string $name): void {
+            Permission::firstOrCreate([
+                'name' => $name,
+                'guard_name' => 'web',
+            ]);
+        });
+
+        $administratorRole = Role::firstOrCreate([
+            'name' => 'Administrator',
+            'guard_name' => 'web',
+        ]);
+
+        $administratorRole->syncPermissions(Permission::all());
+
+        if (! $user->hasRole($administratorRole->name)) {
+            $user->assignRole($administratorRole);
+        }
     }
 }

--- a/resources/js/components/app-sidebar.tsx
+++ b/resources/js/components/app-sidebar.tsx
@@ -13,7 +13,7 @@ import {
 import { dashboard } from '@/routes';
 import { type NavItem } from '@/types';
 import { Link } from '@inertiajs/react';
-import { BookOpen, Folder, LayoutGrid } from 'lucide-react';
+import { BookOpen, Folder, KeyRound, LayoutGrid, Shield } from 'lucide-react';
 import AppLogo from './app-logo';
 
 const mainNavItems: NavItem[] = [
@@ -21,6 +21,16 @@ const mainNavItems: NavItem[] = [
         title: 'Dashboard',
         href: dashboard(),
         icon: LayoutGrid,
+    },
+    {
+        title: 'Roles',
+        href: '/master/roles',
+        icon: Shield,
+    },
+    {
+        title: 'Permissions',
+        href: '/master/permissions',
+        icon: KeyRound,
     },
 ];
 

--- a/resources/js/pages/master/permissions/index.tsx
+++ b/resources/js/pages/master/permissions/index.tsx
@@ -1,0 +1,281 @@
+import InputError from '@/components/input-error';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+    DialogTrigger,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import AppLayout from '@/layouts/app-layout';
+import { type BreadcrumbItem, type SharedData } from '@/types';
+import { Head, useForm, usePage } from '@inertiajs/react';
+import { type FormEvent, useEffect, useState } from 'react';
+import { KeyRound, Pencil, Trash2 } from 'lucide-react';
+
+interface PermissionSummary {
+    id: number;
+    name: string;
+    roles_count: number;
+    is_protected: boolean;
+}
+
+interface PermissionsPageProps {
+    permissions: PermissionSummary[];
+}
+
+const breadcrumbs: BreadcrumbItem[] = [
+    {
+        title: 'Permissions',
+        href: '/master/permissions',
+    },
+];
+
+export default function PermissionsIndex({ permissions }: PermissionsPageProps) {
+    const { flash } = usePage<SharedData>().props;
+    const createForm = useForm({
+        name: '',
+    });
+    const editForm = useForm({
+        name: '',
+    });
+    const { setData: setEditData, reset: resetEditForm, clearErrors: clearEditErrors } = editForm;
+    const deleteForm = useForm({});
+    const [isEditOpen, setIsEditOpen] = useState(false);
+    const [permissionBeingEdited, setPermissionBeingEdited] =
+        useState<PermissionSummary | null>(null);
+
+    useEffect(() => {
+        if (isEditOpen && permissionBeingEdited) {
+            setEditData('name', permissionBeingEdited.name);
+        }
+
+        if (!isEditOpen) {
+            resetEditForm();
+            clearEditErrors();
+        }
+    }, [clearEditErrors, isEditOpen, permissionBeingEdited, resetEditForm, setEditData]);
+
+    const handleCreateSubmit = (event: FormEvent<HTMLFormElement>) => {
+        event.preventDefault();
+
+        createForm.post('/master/permissions', {
+            preserveScroll: true,
+            onSuccess: () => createForm.reset(),
+        });
+    };
+
+    const handleEditSubmit = (event: FormEvent<HTMLFormElement>) => {
+        event.preventDefault();
+        if (!permissionBeingEdited) {
+            return;
+        }
+
+        editForm.put(`/master/permissions/${permissionBeingEdited.id}`, {
+            preserveScroll: true,
+            onSuccess: () => {
+                setIsEditOpen(false);
+                setPermissionBeingEdited(null);
+            },
+        });
+    };
+
+    const handleDelete = (permission: PermissionSummary) => {
+        if (permission.is_protected) {
+            return;
+        }
+
+        if (
+            window.confirm(
+                `Delete the "${permission.name}" permission? This action cannot be undone.`,
+            )
+        ) {
+            deleteForm.delete(`/master/permissions/${permission.id}`, {
+                preserveScroll: true,
+            });
+        }
+    };
+
+    return (
+        <AppLayout breadcrumbs={breadcrumbs}>
+            <Head title="Permissions" />
+
+            <div className="space-y-6 p-4">
+                {flash?.success && (
+                    <Alert className="border-green-200 bg-green-50 text-green-900 dark:border-green-900/40 dark:bg-green-900/20 dark:text-green-100">
+                        <AlertTitle>Success</AlertTitle>
+                        <AlertDescription>{flash.success}</AlertDescription>
+                    </Alert>
+                )}
+
+                {flash?.error && (
+                    <Alert className="border-red-200 bg-red-50 text-red-800 dark:border-red-900/40 dark:bg-red-900/20 dark:text-red-100">
+                        <AlertTitle>Action required</AlertTitle>
+                        <AlertDescription>{flash.error}</AlertDescription>
+                    </Alert>
+                )}
+
+                <div className="grid gap-6 xl:grid-cols-[minmax(0,360px)_minmax(0,1fr)]">
+                    <section className="space-y-6 rounded-xl border border-sidebar-border/70 bg-card p-6 shadow-sm dark:border-sidebar-border">
+                        <header className="space-y-2">
+                            <div className="flex items-center gap-2">
+                                <KeyRound className="h-5 w-5" />
+                                <h2 className="text-lg font-semibold">Create permission</h2>
+                            </div>
+                            <p className="text-sm text-muted-foreground">
+                                Add a new permission that can be assigned to roles.
+                            </p>
+                        </header>
+
+                        <form onSubmit={handleCreateSubmit} className="space-y-4">
+                            <div className="space-y-2">
+                                <label className="text-sm font-medium" htmlFor="permission-name">
+                                    Permission name
+                                </label>
+                                <Input
+                                    id="permission-name"
+                                    name="name"
+                                    placeholder="e.g. manage orders"
+                                    value={createForm.data.name}
+                                    onChange={(event) =>
+                                        createForm.setData('name', event.target.value)
+                                    }
+                                    autoComplete="off"
+                                />
+                                <InputError message={createForm.errors.name} />
+                            </div>
+
+                            <Button type="submit" disabled={createForm.processing} className="w-full">
+                                Create permission
+                            </Button>
+                        </form>
+                    </section>
+
+                    <section className="space-y-4 rounded-xl border border-sidebar-border/70 bg-card p-6 shadow-sm dark:border-sidebar-border">
+                        <header className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                            <div>
+                                <h2 className="text-lg font-semibold">Existing permissions</h2>
+                                <p className="text-sm text-muted-foreground">
+                                    Rename or remove permissions that are no longer needed.
+                                </p>
+                            </div>
+                            <span className="text-sm text-muted-foreground">
+                                {permissions.length} permission{permissions.length === 1 ? '' : 's'}
+                            </span>
+                        </header>
+
+                        {permissions.length === 0 ? (
+                            <p className="rounded-lg border border-dashed border-sidebar-border/70 p-6 text-sm text-muted-foreground text-center dark:border-sidebar-border">
+                                No permissions created yet.
+                            </p>
+                        ) : (
+                            <div className="space-y-4">
+                                {permissions.map((permission) => (
+                                    <article
+                                        key={permission.id}
+                                        className="flex flex-col gap-4 rounded-lg border border-sidebar-border/60 bg-background p-4 shadow-sm transition hover:border-sidebar-border dark:border-sidebar-border sm:flex-row sm:items-center sm:justify-between"
+                                    >
+                                        <div className="space-y-2">
+                                            <div className="flex items-center gap-2">
+                                                <h3 className="text-base font-semibold leading-tight">
+                                                    {permission.name}
+                                                </h3>
+                                                {permission.is_protected && (
+                                                    <Badge variant="secondary" className="uppercase">
+                                                        Protected
+                                                    </Badge>
+                                                )}
+                                            </div>
+                                            <p className="text-xs uppercase tracking-wide text-muted-foreground">
+                                                {permission.roles_count} role{permission.roles_count === 1 ? '' : 's'} using this permission
+                                            </p>
+                                        </div>
+
+                                        <div className="flex items-center gap-2">
+                                            <Dialog
+                                                open={isEditOpen && permissionBeingEdited?.id === permission.id}
+                                                onOpenChange={(open) => {
+                                                    setIsEditOpen(open);
+                                                    if (open) {
+                                                        setPermissionBeingEdited(permission);
+                                                    }
+                                                }}
+                                            >
+                                                <DialogTrigger asChild>
+                                                    <Button
+                                                        size="sm"
+                                                        variant="outline"
+                                                        onClick={() => {
+                                                            setPermissionBeingEdited(permission);
+                                                            setIsEditOpen(true);
+                                                        }}
+                                                    >
+                                                        <Pencil className="mr-2 h-4 w-4" />
+                                                        Edit
+                                                    </Button>
+                                                </DialogTrigger>
+                                                <DialogContent>
+                                                    <DialogHeader>
+                                                        <DialogTitle>Edit permission</DialogTitle>
+                                                        <DialogDescription>
+                                                            Update the permission name. Changes are applied immediately.
+                                                        </DialogDescription>
+                                                    </DialogHeader>
+
+                                                    <form onSubmit={handleEditSubmit} className="space-y-4">
+                                                        <div className="space-y-2">
+                                                            <label className="text-sm font-medium" htmlFor="edit-permission-name">
+                                                                Permission name
+                                                            </label>
+                                                            <Input
+                                                                id="edit-permission-name"
+                                                                value={editForm.data.name}
+                                                                onChange={(event) =>
+                                                                    editForm.setData('name', event.target.value)
+                                                                }
+                                                            />
+                                                            <InputError message={editForm.errors.name} />
+                                                        </div>
+
+                                                        <DialogFooter>
+                                                            <Button
+                                                                type="button"
+                                                                variant="secondary"
+                                                                onClick={() => setIsEditOpen(false)}
+                                                            >
+                                                                Cancel
+                                                            </Button>
+                                                            <Button type="submit" disabled={editForm.processing}>
+                                                                Save changes
+                                                            </Button>
+                                                        </DialogFooter>
+                                                    </form>
+                                                </DialogContent>
+                                            </Dialog>
+
+                                            <Button
+                                                size="sm"
+                                                variant="destructive"
+                                                onClick={() => handleDelete(permission)}
+                                                disabled={permission.is_protected || deleteForm.processing}
+                                            >
+                                                <Trash2 className="mr-2 h-4 w-4" />
+                                                Delete
+                                            </Button>
+                                        </div>
+                                    </article>
+                                ))}
+                            </div>
+                        )}
+                    </section>
+                </div>
+            </div>
+        </AppLayout>
+    );
+}
+

--- a/resources/js/pages/master/roles/index.tsx
+++ b/resources/js/pages/master/roles/index.tsx
@@ -1,0 +1,416 @@
+import InputError from '@/components/input-error';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+    DialogTrigger,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import AppLayout from '@/layouts/app-layout';
+import { type BreadcrumbItem, type SharedData } from '@/types';
+import { Head, useForm, usePage } from '@inertiajs/react';
+import { type FormEvent, useEffect, useMemo, useState } from 'react';
+import { PlusCircle, Shield, Trash2 } from 'lucide-react';
+
+interface PermissionSummary {
+    id: number;
+    name: string;
+}
+
+interface RoleSummary {
+    id: number;
+    name: string;
+    users_count: number;
+    permissions: PermissionSummary[];
+    is_protected: boolean;
+}
+
+interface RolesPageProps {
+    roles: RoleSummary[];
+    permissions: PermissionSummary[];
+}
+
+const breadcrumbs: BreadcrumbItem[] = [
+    {
+        title: 'Roles',
+        href: '/master/roles',
+    },
+];
+
+const applyPermissionSelection = (
+    selected: number[],
+    permissionId: number,
+    isChecked: boolean,
+) => {
+    if (isChecked) {
+        return selected.includes(permissionId)
+            ? selected
+            : [...selected, permissionId];
+    }
+
+    return selected.filter((id) => id !== permissionId);
+};
+
+export default function RolesIndex({
+    roles,
+    permissions,
+}: RolesPageProps) {
+    const { flash } = usePage<SharedData>().props;
+    const createForm = useForm({
+        name: '',
+        permissions: [] as number[],
+    });
+    const editForm = useForm({
+        name: '',
+        permissions: [] as number[],
+    });
+    const { setData: setEditData, reset: resetEditForm, clearErrors: clearEditErrors } = editForm;
+    const deleteForm = useForm({});
+    const [isEditOpen, setIsEditOpen] = useState(false);
+    const [roleBeingEdited, setRoleBeingEdited] = useState<RoleSummary | null>(
+        null,
+    );
+
+    useEffect(() => {
+        if (isEditOpen && roleBeingEdited) {
+            setEditData('name', roleBeingEdited.name);
+            setEditData(
+                'permissions',
+                roleBeingEdited.permissions.map((permission) => permission.id),
+            );
+        }
+
+        if (!isEditOpen) {
+            resetEditForm();
+            clearEditErrors();
+        }
+    }, [clearEditErrors, isEditOpen, resetEditForm, roleBeingEdited, setEditData]);
+
+    const totalPermissions = useMemo(() => permissions.length, [permissions.length]);
+
+    const handleCreateSubmit = (event: FormEvent<HTMLFormElement>) => {
+        event.preventDefault();
+
+        createForm.post('/master/roles', {
+            preserveScroll: true,
+            onSuccess: () => createForm.reset(),
+        });
+    };
+
+    const handleEditSubmit = (event: FormEvent<HTMLFormElement>) => {
+        event.preventDefault();
+        if (!roleBeingEdited) {
+            return;
+        }
+
+        editForm.put(`/master/roles/${roleBeingEdited.id}`, {
+            preserveScroll: true,
+            onSuccess: () => {
+                setIsEditOpen(false);
+                setRoleBeingEdited(null);
+            },
+        });
+    };
+
+    const handleDelete = (role: RoleSummary) => {
+        if (role.is_protected) {
+            return;
+        }
+
+        if (
+            window.confirm(
+                `Delete the ${role.name} role? This will remove it from all users.`,
+            )
+        ) {
+            deleteForm.delete(`/master/roles/${role.id}`, {
+                preserveScroll: true,
+            });
+        }
+    };
+
+    return (
+        <AppLayout breadcrumbs={breadcrumbs}>
+            <Head title="Roles" />
+
+            <div className="space-y-6 p-4">
+                {flash?.success && (
+                    <Alert className="border-green-200 bg-green-50 text-green-900 dark:border-green-900/40 dark:bg-green-900/20 dark:text-green-100">
+                        <AlertTitle>Success</AlertTitle>
+                        <AlertDescription>{flash.success}</AlertDescription>
+                    </Alert>
+                )}
+
+                {flash?.error && (
+                    <Alert className="border-red-200 bg-red-50 text-red-800 dark:border-red-900/40 dark:bg-red-900/20 dark:text-red-100">
+                        <AlertTitle>Action required</AlertTitle>
+                        <AlertDescription>{flash.error}</AlertDescription>
+                    </Alert>
+                )}
+
+                <div className="grid gap-6 xl:grid-cols-[minmax(0,360px)_minmax(0,1fr)]">
+                    <section className="space-y-6 rounded-xl border border-sidebar-border/70 bg-card p-6 shadow-sm dark:border-sidebar-border">
+                        <header className="space-y-2">
+                            <div className="flex items-center gap-2">
+                                <Shield className="h-5 w-5" />
+                                <h2 className="text-lg font-semibold">Create role</h2>
+                            </div>
+                            <p className="text-sm text-muted-foreground">
+                                Define a new role and choose which permissions it should have access to.
+                            </p>
+                        </header>
+
+                        <form onSubmit={handleCreateSubmit} className="space-y-4">
+                            <div className="space-y-2">
+                                <Label htmlFor="role-name">Role name</Label>
+                                <Input
+                                    id="role-name"
+                                    name="name"
+                                    placeholder="e.g. Support Agent"
+                                    value={createForm.data.name}
+                                    onChange={(event) =>
+                                        createForm.setData('name', event.target.value)
+                                    }
+                                    autoComplete="off"
+                                />
+                                <InputError message={createForm.errors.name} />
+                            </div>
+
+                            <div className="space-y-3">
+                                <div className="flex items-center justify-between">
+                                    <Label>Permissions</Label>
+                                    <span className="text-xs text-muted-foreground">
+                                        {createForm.data.permissions.length} of {totalPermissions} selected
+                                    </span>
+                                </div>
+
+                                {permissions.length === 0 ? (
+                                    <p className="rounded-lg border border-dashed border-sidebar-border/70 p-3 text-sm text-muted-foreground dark:border-sidebar-border">
+                                        Create permissions first to assign them to roles.
+                                    </p>
+                                ) : (
+                                    <div className="grid gap-2">
+                                        {permissions.map((permission) => (
+                                            <label
+                                                key={permission.id}
+                                                className="flex cursor-pointer items-center gap-3 rounded-lg border border-transparent px-3 py-2 transition hover:border-sidebar-border/70"
+                                            >
+                                                <Checkbox
+                                                    checked={createForm.data.permissions.includes(
+                                                        permission.id,
+                                                    )}
+                                                    onCheckedChange={(checked) =>
+                                                        createForm.setData(
+                                                            'permissions',
+                                                            applyPermissionSelection(
+                                                                createForm.data.permissions,
+                                                                permission.id,
+                                                                checked === true,
+                                                            ),
+                                                        )
+                                                    }
+                                                />
+                                                <span className="text-sm font-medium">
+                                                    {permission.name}
+                                                </span>
+                                            </label>
+                                        ))}
+                                    </div>
+                                )}
+
+                                <InputError message={createForm.errors.permissions} />
+                            </div>
+
+                            <Button type="submit" disabled={createForm.processing} className="w-full">
+                                <PlusCircle className="mr-2 h-4 w-4" />
+                                Save role
+                            </Button>
+                        </form>
+                    </section>
+
+                    <section className="space-y-4 rounded-xl border border-sidebar-border/70 bg-card p-6 shadow-sm dark:border-sidebar-border">
+                        <header className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                            <div>
+                                <h2 className="text-lg font-semibold">Existing roles</h2>
+                                <p className="text-sm text-muted-foreground">
+                                    Assign permissions or make changes to existing roles.
+                                </p>
+                            </div>
+                            <span className="text-sm text-muted-foreground">
+                                {roles.length} role{roles.length === 1 ? '' : 's'}
+                            </span>
+                        </header>
+
+                        {roles.length === 0 ? (
+                            <p className="rounded-lg border border-dashed border-sidebar-border/70 p-6 text-sm text-muted-foreground text-center dark:border-sidebar-border">
+                                No roles created yet.
+                            </p>
+                        ) : (
+                            <div className="space-y-4">
+                                {roles.map((role) => (
+                                    <article
+                                        key={role.id}
+                                        className="space-y-3 rounded-lg border border-sidebar-border/60 bg-background p-4 shadow-sm transition hover:border-sidebar-border dark:border-sidebar-border"
+                                    >
+                                        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                                            <div className="space-y-1">
+                                                <h3 className="text-base font-semibold leading-tight">
+                                                    {role.name}
+                                                </h3>
+                                                <p className="text-xs uppercase tracking-wide text-muted-foreground">
+                                                    {role.users_count} user{role.users_count === 1 ? '' : 's'} assigned
+                                                </p>
+                                            </div>
+
+                                            <div className="flex items-center gap-2">
+                                                <Dialog
+                                                    open={isEditOpen && roleBeingEdited?.id === role.id}
+                                                    onOpenChange={(open) => {
+                                                        setIsEditOpen(open);
+                                                        if (open) {
+                                                            setRoleBeingEdited(role);
+                                                        }
+                                                    }}
+                                                >
+                                                    <DialogTrigger asChild>
+                                                        <Button
+                                                            size="sm"
+                                                            variant="outline"
+                                                            onClick={() => {
+                                                                setRoleBeingEdited(role);
+                                                                setIsEditOpen(true);
+                                                            }}
+                                                        >
+                                                            Edit
+                                                        </Button>
+                                                    </DialogTrigger>
+                                                    <DialogContent>
+                                                        <DialogHeader>
+                                                            <DialogTitle>Edit role</DialogTitle>
+                                                            <DialogDescription>
+                                                                Update the role name or adjust its permissions.
+                                                            </DialogDescription>
+                                                        </DialogHeader>
+
+                                                        <form
+                                                            onSubmit={handleEditSubmit}
+                                                            className="space-y-4"
+                                                        >
+                                                            <div className="space-y-2">
+                                                                <Label htmlFor="edit-role-name">
+                                                                    Role name
+                                                                </Label>
+                                                                <Input
+                                                                    id="edit-role-name"
+                                                                    value={editForm.data.name}
+                                                                    onChange={(event) =>
+                                                                        editForm.setData(
+                                                                            'name',
+                                                                            event.target.value,
+                                                                        )
+                                                                    }
+                                                                />
+                                                                <InputError
+                                                                    message={editForm.errors.name}
+                                                                />
+                                                            </div>
+
+                                                            <div className="space-y-3">
+                                                                <Label>Permissions</Label>
+                                                                <div className="grid gap-2">
+                                                                    {permissions.map((permission) => (
+                                                                        <label
+                                                                            key={permission.id}
+                                                                            className="flex cursor-pointer items-center gap-3 rounded-lg border border-transparent px-3 py-2 transition hover:border-sidebar-border/70"
+                                                                        >
+                                                                            <Checkbox
+                                                                                checked={editForm.data.permissions.includes(
+                                                                                    permission.id,
+                                                                                )}
+                                                                                onCheckedChange={(checked) =>
+                                                                                    editForm.setData(
+                                                                                        'permissions',
+                                                                                        applyPermissionSelection(
+                                                                                            editForm.data.permissions,
+                                                                                            permission.id,
+                                                                                            checked === true,
+                                                                                        ),
+                                                                                    )
+                                                                                }
+                                                                            />
+                                                                            <span className="text-sm font-medium">
+                                                                                {permission.name}
+                                                                            </span>
+                                                                        </label>
+                                                                    ))}
+                                                                </div>
+                                                                <InputError
+                                                                    message={editForm.errors.permissions}
+                                                                />
+                                                            </div>
+
+                                                            <DialogFooter>
+                                                                <Button
+                                                                    type="button"
+                                                                    variant="secondary"
+                                                                    onClick={() => setIsEditOpen(false)}
+                                                                >
+                                                                    Cancel
+                                                                </Button>
+                                                                <Button
+                                                                    type="submit"
+                                                                    disabled={editForm.processing}
+                                                                >
+                                                                    Save changes
+                                                                </Button>
+                                                            </DialogFooter>
+                                                        </form>
+                                                    </DialogContent>
+                                                </Dialog>
+
+                                                <Button
+                                                    size="sm"
+                                                    variant="destructive"
+                                                    onClick={() => handleDelete(role)}
+                                                    disabled={role.is_protected || deleteForm.processing}
+                                                >
+                                                    <Trash2 className="mr-2 h-4 w-4" />
+                                                    Delete
+                                                </Button>
+                                            </div>
+                                        </div>
+
+                                        {role.permissions.length > 0 ? (
+                                            <div className="flex flex-wrap gap-2">
+                                                {role.permissions.map((permission) => (
+                                                    <Badge
+                                                        key={`${role.id}-${permission.id}`}
+                                                        variant="secondary"
+                                                    >
+                                                        {permission.name}
+                                                    </Badge>
+                                                ))}
+                                            </div>
+                                        ) : (
+                                            <p className="text-sm text-muted-foreground">
+                                                No permissions assigned to this role yet.
+                                            </p>
+                                        )}
+                                    </article>
+                                ))}
+                            </div>
+                        )}
+                    </section>
+                </div>
+            </div>
+        </AppLayout>
+    );
+}
+

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -27,6 +27,10 @@ export interface SharedData {
     quote: { message: string; author: string };
     auth: Auth;
     sidebarOpen: boolean;
+    flash?: {
+        success?: string;
+        error?: string;
+    };
     [key: string]: unknown;
 }
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,5 +1,7 @@
 <?php
 
+use App\Http\Controllers\Master\PermissionController;
+use App\Http\Controllers\Master\RoleController;
 use Illuminate\Support\Facades\Route;
 use Inertia\Inertia;
 
@@ -11,6 +13,11 @@ Route::middleware(['auth', 'verified'])->group(function () {
     Route::get('dashboard', function () {
         return Inertia::render('dashboard');
     })->name('dashboard');
+
+    Route::prefix('master')->name('master.')->group(function () {
+        Route::resource('roles', RoleController::class)->except(['create', 'edit', 'show']);
+        Route::resource('permissions', PermissionController::class)->except(['create', 'edit', 'show']);
+    });
 });
 
 require __DIR__.'/settings.php';


### PR DESCRIPTION
## Summary
- add controllers, requests, and seeder updates to manage roles and permissions with protected defaults and shared flash messaging
- add Inertia pages and sidebar links for creating, editing, and deleting roles and permissions

## Testing
- npm run lint
- php artisan test *(fails: MissingAppKeyException because no application encryption key is configured in the test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68db906b1fe0832f9b3cb7bc35fe0c47