### PR TITLE
Add point-of-sale flow with customer display and admin tax settings

### DIFF
--- a/app/Http/Controllers/Settings/StoreSettingsController.php
+++ b/app/Http/Controllers/Settings/StoreSettingsController.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Http\Controllers\Settings;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Settings\UpdateStoreSettingsRequest;
+use App\Models\StoreSetting;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\Redirect;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class StoreSettingsController extends Controller
+{
+    public function edit(): Response
+    {
+        $settings = StoreSetting::current();
+
+        return Inertia::render('settings/store', [
+            'settings' => [
+                'ppn_rate' => (float) $settings->ppn_rate,
+                'updated_at' => $settings->updated_at?->toIso8601String(),
+            ],
+        ]);
+    }
+
+    public function update(UpdateStoreSettingsRequest $request): RedirectResponse
+    {
+        $settings = StoreSetting::current();
+        $settings->update([
+            'ppn_rate' => $request->float('ppn_rate'),
+        ]);
+
+        return Redirect::back()->with('success', 'Store settings updated successfully.');
+    }
+}

--- a/app/Http/Controllers/Transactions/TransactionController.php
+++ b/app/Http/Controllers/Transactions/TransactionController.php
@@ -1,0 +1,194 @@
+<?php
+
+namespace App\Http\Controllers\Transactions;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Transactions\StoreTransactionRequest;
+use App\Models\Product;
+use App\Models\StoreSetting;
+use App\Models\Transaction;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Redirect;
+use Illuminate\Support\Str;
+use Illuminate\Validation\ValidationException;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class TransactionController extends Controller
+{
+    public function employee(): Response
+    {
+        $settings = StoreSetting::current();
+
+        return Inertia::render('transactions/employee', [
+            'ppnRate' => (float) $settings->ppn_rate,
+            'productLookupUrl' => route('transactions.products.show', ['product' => '__BARCODE__']),
+            'storeUrl' => route('transactions.store'),
+            'recentTransactionId' => session('recentTransactionId'),
+            'customerBaseUrl' => route('transactions.customer', ['transaction' => '__ID__']),
+            'customerLatestUrl' => route('transactions.customer.latest'),
+        ]);
+    }
+
+    public function store(StoreTransactionRequest $request): RedirectResponse
+    {
+        $settings = StoreSetting::current();
+        $ppnRate = (float) $settings->ppn_rate;
+
+        $items = collect($request->validated('items'))
+            ->map(function (array $item) use ($ppnRate) {
+                $product = Product::query()->findOrFail($item['product_id']);
+                $quantity = (int) $item['quantity'];
+
+                if ($quantity < 1) {
+                    throw ValidationException::withMessages([
+                        'items' => 'Each product must have a quantity of at least 1.',
+                    ]);
+                }
+
+                if ($product->stock < $quantity) {
+                    throw ValidationException::withMessages([
+                        'items' => "Insufficient stock for {$product->name}.",
+                    ]);
+                }
+
+                $unitPrice = (float) $product->price;
+                $lineSubtotal = round($unitPrice * $quantity, 2);
+                $lineTax = round($lineSubtotal * ($ppnRate / 100), 2);
+                $lineTotal = round($lineSubtotal + $lineTax, 2);
+
+                return [
+                    'product' => $product,
+                    'quantity' => $quantity,
+                    'unit_price' => $unitPrice,
+                    'line_subtotal' => $lineSubtotal,
+                    'line_tax' => $lineTax,
+                    'line_total' => $lineTotal,
+                ];
+            });
+
+        if ($items->isEmpty()) {
+            throw ValidationException::withMessages([
+                'items' => 'Add at least one product before completing the transaction.',
+            ]);
+        }
+
+        $subtotal = $items->sum('line_subtotal');
+        $taxTotal = $items->sum('line_tax');
+        $total = $items->sum('line_total');
+
+        $transaction = DB::transaction(function () use ($items, $subtotal, $taxTotal, $total, $ppnRate, $request) {
+            $transaction = Transaction::query()->create([
+                'number' => $this->generateNumber(),
+                'user_id' => $request->user()?->id,
+                'items_count' => $items->sum('quantity'),
+                'ppn_rate' => $ppnRate,
+                'subtotal' => $subtotal,
+                'tax_total' => $taxTotal,
+                'total' => $total,
+            ]);
+
+            $transaction->items()->createMany(
+                $items->map(function (array $item) use ($transaction, $ppnRate) {
+                    /** @var \App\Models\Product $product */
+                    $product = $item['product'];
+
+                    $product->decrement('stock', $item['quantity']);
+
+                    return [
+                        'product_id' => $product->id,
+                        'barcode' => $product->barcode,
+                        'name' => $product->name,
+                        'quantity' => $item['quantity'],
+                        'unit_price' => $item['unit_price'],
+                        'tax_rate' => $ppnRate,
+                        'tax_amount' => $item['line_tax'],
+                        'line_total' => $item['line_total'],
+                    ];
+                })->all(),
+            );
+
+            return $transaction;
+        });
+
+        return Redirect::route('transactions.employee')
+            ->with('success', 'Transaction completed successfully.')
+            ->with('recentTransactionId', $transaction->id);
+    }
+
+    public function showProduct(Product $product): JsonResponse
+    {
+        return response()->json([
+            'id' => $product->id,
+            'barcode' => $product->barcode,
+            'name' => $product->name,
+            'price' => (float) $product->price,
+            'stock' => $product->stock,
+        ]);
+    }
+
+    public function customer(Transaction $transaction): Response
+    {
+        $transaction->loadMissing(['items', 'user']);
+
+        return Inertia::render('transactions/customer', [
+            'transaction' => $this->formatTransaction($transaction),
+            'autoRefresh' => false,
+            'latestUrl' => route('transactions.customer.latest'),
+        ]);
+    }
+
+    public function latest(): Response
+    {
+        $transaction = Transaction::query()
+            ->latest()
+            ->with(['items', 'user'])
+            ->first();
+
+        return Inertia::render('transactions/customer', [
+            'transaction' => $transaction ? $this->formatTransaction($transaction) : null,
+            'autoRefresh' => true,
+            'latestUrl' => route('transactions.customer.latest'),
+        ]);
+    }
+
+    protected function formatTransaction(Transaction $transaction): array
+    {
+        return [
+            'id' => $transaction->id,
+            'number' => $transaction->number,
+            'created_at' => $transaction->created_at?->toIso8601String(),
+            'ppn_rate' => (float) $transaction->ppn_rate,
+            'subtotal' => (float) $transaction->subtotal,
+            'tax_total' => (float) $transaction->tax_total,
+            'total' => (float) $transaction->total,
+            'items_count' => $transaction->items_count,
+            'user' => $transaction->user ? [
+                'id' => $transaction->user->id,
+                'name' => $transaction->user->name,
+            ] : null,
+            'items' => $transaction->items
+                ->map(fn ($item) => [
+                    'id' => $item->id,
+                    'product_id' => $item->product_id,
+                    'barcode' => $item->barcode,
+                    'name' => $item->name,
+                    'quantity' => $item->quantity,
+                    'unit_price' => (float) $item->unit_price,
+                    'tax_rate' => (float) $item->tax_rate,
+                    'tax_amount' => (float) $item->tax_amount,
+                    'line_total' => (float) $item->line_total,
+                ])
+                ->toArray(),
+        ];
+    }
+
+    protected function generateNumber(): string
+    {
+        $prefix = 'TRX-' . now()->format('Ymd-His');
+
+        return $prefix . '-' . Str::upper(Str::random(4));
+    }
+}

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -38,12 +38,19 @@ class HandleInertiaRequests extends Middleware
     {
         [$message, $author] = str(Inspiring::quotes()->random())->explode('-');
 
+        $user = $request->user();
+
+        if ($user) {
+            $user->setAttribute('permissions', $user->getAllPermissions()->pluck('name')->all());
+            $user->setAttribute('roles', $user->getRoleNames()->all());
+        }
+
         return [
             ...parent::share($request),
             'name' => config('app.name'),
             'quote' => ['message' => trim($message), 'author' => trim($author)],
             'auth' => [
-                'user' => $request->user(),
+                'user' => $user,
             ],
             'sidebarOpen' => ! $request->hasCookie('sidebar_state') || $request->cookie('sidebar_state') === 'true',
             'flash' => [

--- a/app/Http/Requests/Settings/UpdateStoreSettingsRequest.php
+++ b/app/Http/Requests/Settings/UpdateStoreSettingsRequest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Requests\Settings;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateStoreSettingsRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return $this->user()?->can('manage settings') ?? false;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'ppn_rate' => ['required', 'numeric', 'between:0,100'],
+        ];
+    }
+}

--- a/app/Http/Requests/Transactions/StoreTransactionRequest.php
+++ b/app/Http/Requests/Transactions/StoreTransactionRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Requests\Transactions;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreTransactionRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return $this->user() !== null;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'items' => ['required', 'array', 'min:1'],
+            'items.*.product_id' => ['required', 'integer', 'exists:products,id'],
+            'items.*.quantity' => ['required', 'integer', 'min:1'],
+        ];
+    }
+}

--- a/app/Models/StoreSetting.php
+++ b/app/Models/StoreSetting.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class StoreSetting extends Model
+{
+    use HasFactory;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var list<string>
+     */
+    protected $fillable = [
+        'ppn_rate',
+    ];
+
+    /**
+     * The attributes that should be cast.
+     *
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'ppn_rate' => 'decimal:2',
+    ];
+
+    public static function current(): self
+    {
+        return static::query()->first() ?? static::query()->create([
+            'ppn_rate' => 11.0,
+        ]);
+    }
+}

--- a/app/Models/Transaction.php
+++ b/app/Models/Transaction.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Transaction extends Model
+{
+    use HasFactory;
+
+    /**
+     * @var list<string>
+     */
+    protected $fillable = [
+        'number',
+        'user_id',
+        'items_count',
+        'ppn_rate',
+        'subtotal',
+        'tax_total',
+        'total',
+    ];
+
+    /**
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'ppn_rate' => 'decimal:2',
+        'subtotal' => 'decimal:2',
+        'tax_total' => 'decimal:2',
+        'total' => 'decimal:2',
+    ];
+
+    public function items(): HasMany
+    {
+        return $this->hasMany(TransactionItem::class);
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Models/TransactionItem.php
+++ b/app/Models/TransactionItem.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class TransactionItem extends Model
+{
+    use HasFactory;
+
+    /**
+     * @var list<string>
+     */
+    protected $fillable = [
+        'transaction_id',
+        'product_id',
+        'barcode',
+        'name',
+        'quantity',
+        'unit_price',
+        'tax_rate',
+        'tax_amount',
+        'line_total',
+    ];
+
+    /**
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'quantity' => 'integer',
+        'unit_price' => 'decimal:2',
+        'tax_rate' => 'decimal:2',
+        'tax_amount' => 'decimal:2',
+        'line_total' => 'decimal:2',
+    ];
+
+    public function transaction(): BelongsTo
+    {
+        return $this->belongsTo(Transaction::class);
+    }
+
+    public function product(): BelongsTo
+    {
+        return $this->belongsTo(Product::class);
+    }
+}

--- a/database/migrations/2025_10_01_000000_create_store_settings_table.php
+++ b/database/migrations/2025_10_01_000000_create_store_settings_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('store_settings', function (Blueprint $table): void {
+            $table->id();
+            $table->decimal('ppn_rate', 5, 2)->default(11.00);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('store_settings');
+    }
+};

--- a/database/migrations/2025_10_01_000100_create_transactions_table.php
+++ b/database/migrations/2025_10_01_000100_create_transactions_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('transactions', function (Blueprint $table): void {
+            $table->id();
+            $table->string('number')->unique();
+            $table->foreignId('user_id')->nullable()->constrained()->nullOnDelete();
+            $table->unsignedInteger('items_count');
+            $table->decimal('ppn_rate', 5, 2);
+            $table->decimal('subtotal', 12, 2);
+            $table->decimal('tax_total', 12, 2);
+            $table->decimal('total', 12, 2);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('transactions');
+    }
+};

--- a/database/migrations/2025_10_01_000200_create_transaction_items_table.php
+++ b/database/migrations/2025_10_01_000200_create_transaction_items_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('transaction_items', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('transaction_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('product_id')->nullable()->constrained()->nullOnDelete();
+            $table->string('barcode');
+            $table->string('name');
+            $table->unsignedInteger('quantity');
+            $table->decimal('unit_price', 12, 2);
+            $table->decimal('tax_rate', 5, 2);
+            $table->decimal('tax_amount', 12, 2);
+            $table->decimal('line_total', 12, 2);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('transaction_items');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -2,6 +2,7 @@
 
 namespace Database\Seeders;
 
+use App\Models\StoreSetting;
 use App\Models\User;
 // use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
@@ -31,6 +32,7 @@ class DatabaseSeeder extends Seeder
             'manage roles',
             'manage permissions',
             'manage users',
+            'manage settings',
         ])->each(static function (string $name): void {
             Permission::firstOrCreate([
                 'name' => $name,
@@ -48,5 +50,7 @@ class DatabaseSeeder extends Seeder
         if (! $user->hasRole($administratorRole->name)) {
             $user->assignRole($administratorRole);
         }
+
+        StoreSetting::current();
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
                 "@types/react": "^19.0.3",
                 "@types/react-dom": "^19.0.2",
                 "@vitejs/plugin-react": "^4.6.0",
+                "@zxing/browser": "^0.1.5",
                 "class-variance-authority": "^0.7.1",
                 "clsx": "^2.1.1",
                 "concurrently": "^9.0.1",
@@ -3011,6 +3012,41 @@
             "peerDependencies": {
                 "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
             }
+        },
+        "node_modules/@zxing/browser": {
+            "version": "0.1.5",
+            "resolved": "https://registry.npmjs.org/@zxing/browser/-/browser-0.1.5.tgz",
+            "integrity": "sha512-4Lmrn/il4+UNb87Gk8h1iWnhj39TASEHpd91CwwSJtY5u+wa0iH9qS0wNLAWbNVYXR66WmT5uiMhZ7oVTrKfxw==",
+            "license": "MIT",
+            "optionalDependencies": {
+                "@zxing/text-encoding": "^0.9.0"
+            },
+            "peerDependencies": {
+                "@zxing/library": "^0.21.0"
+            }
+        },
+        "node_modules/@zxing/library": {
+            "version": "0.21.3",
+            "resolved": "https://registry.npmjs.org/@zxing/library/-/library-0.21.3.tgz",
+            "integrity": "sha512-hZHqFe2JyH/ZxviJZosZjV+2s6EDSY0O24R+FQmlWZBZXP9IqMo7S3nb3+2LBWxodJQkSurdQGnqE7KXqrYgow==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "ts-custom-error": "^3.2.1"
+            },
+            "engines": {
+                "node": ">= 10.4.0"
+            },
+            "optionalDependencies": {
+                "@zxing/text-encoding": "~0.9.0"
+            }
+        },
+        "node_modules/@zxing/text-encoding": {
+            "version": "0.9.0",
+            "resolved": "https://registry.npmjs.org/@zxing/text-encoding/-/text-encoding-0.9.0.tgz",
+            "integrity": "sha512-U/4aVJ2mxI0aDNI8Uq0wEhMgY+u4CNtEb0om3+y3+niDAsoTCOB33UF0sxpzqzdqXLqmvc+vZyAt4O8pPdfkwA==",
+            "license": "(Unlicense OR Apache-2.0)",
+            "optional": true
         },
         "node_modules/acorn": {
             "version": "8.15.0",
@@ -6788,6 +6824,16 @@
             },
             "peerDependencies": {
                 "typescript": ">=4.8.4"
+            }
+        },
+        "node_modules/ts-custom-error": {
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/ts-custom-error/-/ts-custom-error-3.3.1.tgz",
+            "integrity": "sha512-5OX1tzOjxWEgsr/YEUWSuPrQ00deKLh6D7OTWcvNHm12/7QPyRh8SYpyWvA4IZv8H/+GQWQEh/kwo95Q9OVW1A==",
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=14.0.0"
             }
         },
         "node_modules/tslib": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
         "@tailwindcss/vite": "^4.1.11",
         "@types/react": "^19.0.3",
         "@types/react-dom": "^19.0.2",
+        "@zxing/browser": "^0.1.5",
         "@vitejs/plugin-react": "^4.6.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",

--- a/resources/js/components/app-sidebar.tsx
+++ b/resources/js/components/app-sidebar.tsx
@@ -13,7 +13,17 @@ import {
 import { dashboard } from '@/routes';
 import { type NavItem } from '@/types';
 import { Link } from '@inertiajs/react';
-import { BookOpen, Folder, KeyRound, LayoutGrid, Package, Shield, Users} from 'lucide-react';
+import {
+    BookOpen,
+    Folder,
+    KeyRound,
+    LayoutGrid,
+    MonitorPlay,
+    Package,
+    Shield,
+    ShoppingCart,
+    Users,
+} from 'lucide-react';
 import AppLogo from './app-logo';
 
 const mainNavItems: NavItem[] = [
@@ -41,6 +51,16 @@ const mainNavItems: NavItem[] = [
         title: 'Products',
         href: '/master/products',
         icon: Package,
+    },
+    {
+        title: 'POS',
+        href: '/transactions/employee',
+        icon: ShoppingCart,
+    },
+    {
+        title: 'Customer Display',
+        href: '/transactions/customer/latest',
+        icon: MonitorPlay,
     },
 ];
 

--- a/resources/js/components/nav-user.tsx
+++ b/resources/js/components/nav-user.tsx
@@ -21,6 +21,10 @@ export function NavUser() {
     const { state } = useSidebar();
     const isMobile = useIsMobile();
 
+    if (!auth.user) {
+        return null;
+    }
+
     return (
         <SidebarMenu>
             <SidebarMenuItem>

--- a/resources/js/layouts/customer-layout.tsx
+++ b/resources/js/layouts/customer-layout.tsx
@@ -1,0 +1,11 @@
+import { type PropsWithChildren } from 'react';
+
+export default function CustomerLayout({ children }: PropsWithChildren) {
+    return (
+        <div className="flex min-h-screen w-full flex-col bg-neutral-100 text-neutral-900 dark:bg-neutral-950 dark:text-neutral-100">
+            <main className="mx-auto flex w-full max-w-5xl flex-1 flex-col gap-6 p-6">
+                {children}
+            </main>
+        </div>
+    );
+}

--- a/resources/js/layouts/settings/layout.tsx
+++ b/resources/js/layouts/settings/layout.tsx
@@ -6,11 +6,11 @@ import { edit as editAppearance } from '@/routes/appearance';
 import { edit as editPassword } from '@/routes/password';
 import { edit } from '@/routes/profile';
 import { show } from '@/routes/two-factor';
-import { type NavItem } from '@/types';
-import { Link } from '@inertiajs/react';
+import { type NavItem, type SharedData } from '@/types';
+import { Link, usePage } from '@inertiajs/react';
 import { type PropsWithChildren } from 'react';
 
-const sidebarNavItems: NavItem[] = [
+const baseSidebarNavItems: NavItem[] = [
     {
         title: 'Profile',
         href: edit(),
@@ -34,12 +34,24 @@ const sidebarNavItems: NavItem[] = [
 ];
 
 export default function SettingsLayout({ children }: PropsWithChildren) {
+    const { auth } = usePage<SharedData>().props;
+    const canManageSettings = auth.user?.permissions?.includes('manage settings');
+    const sidebarNavItems = [...baseSidebarNavItems];
+
+    if (canManageSettings) {
+        sidebarNavItems.push({
+            title: 'Store',
+            href: '/settings/store',
+            icon: null,
+        });
+    }
+
+    const currentPath = typeof window !== 'undefined' ? window.location.pathname : '';
+
     // When server-side rendering, we only render the layout on the client...
     if (typeof window === 'undefined') {
         return null;
     }
-
-    const currentPath = window.location.pathname;
 
     return (
         <div className="px-4 py-6">

--- a/resources/js/pages/settings/store.tsx
+++ b/resources/js/pages/settings/store.tsx
@@ -1,0 +1,73 @@
+import InputError from '@/components/input-error';
+import SettingsLayout from '@/layouts/settings/layout';
+import { type SharedData } from '@/types';
+import { Head, useForm, usePage } from '@inertiajs/react';
+import { FormEvent } from 'react';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+interface StoreSettingsPageProps {
+    settings: {
+        ppn_rate: number;
+        updated_at?: string | null;
+    };
+}
+
+export default function StoreSettings({ settings }: StoreSettingsPageProps) {
+    const { flash } = usePage<SharedData>().props;
+    const form = useForm<{ ppn_rate: string }>({
+        ppn_rate: settings.ppn_rate.toString(),
+    });
+
+    const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+        event.preventDefault();
+        form.put('/settings/store');
+    };
+
+    return (
+        <SettingsLayout>
+            <Head title="Store settings" />
+
+            <div className="space-y-6">
+                <div>
+                    <h2 className="text-lg font-semibold">Store preferences</h2>
+                    <p className="text-sm text-muted-foreground">
+                        Configure tax settings that are used when recording transactions.
+                    </p>
+                </div>
+
+                {flash?.success && (
+                    <Alert className="border-green-200 bg-green-50 text-green-900 dark:border-green-900/40 dark:bg-green-900/20 dark:text-green-100">
+                        <AlertTitle>Success</AlertTitle>
+                        <AlertDescription>{flash.success}</AlertDescription>
+                    </Alert>
+                )}
+
+                <form className="space-y-4" onSubmit={handleSubmit}>
+                    <div className="space-y-2">
+                        <Label htmlFor="ppn_rate">PPN rate (%)</Label>
+                        <Input
+                            id="ppn_rate"
+                            name="ppn_rate"
+                            type="number"
+                            min={0}
+                            max={100}
+                            step="0.01"
+                            value={form.data.ppn_rate}
+                            onChange={(event) => form.setData('ppn_rate', event.target.value)}
+                        />
+                        <InputError message={form.errors.ppn_rate} />
+                    </div>
+
+                    <div className="flex items-center justify-end gap-2">
+                        <Button type="submit" disabled={form.processing}>
+                            Save changes
+                        </Button>
+                    </div>
+                </form>
+            </div>
+        </SettingsLayout>
+    );
+}

--- a/resources/js/pages/transactions/customer.tsx
+++ b/resources/js/pages/transactions/customer.tsx
@@ -1,0 +1,177 @@
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
+import CustomerLayout from '@/layouts/customer-layout';
+import { Head, router } from '@inertiajs/react';
+import { useEffect } from 'react';
+import { RefreshCcw } from 'lucide-react';
+
+interface TransactionItemSummary {
+    id: number;
+    barcode: string;
+    name: string;
+    quantity: number;
+    unit_price: number;
+    tax_amount: number;
+    line_total: number;
+}
+
+interface TransactionSummary {
+    id: number;
+    number: string;
+    created_at: string | null;
+    ppn_rate: number;
+    subtotal: number;
+    tax_total: number;
+    total: number;
+    items_count: number;
+    user: { id: number; name: string } | null;
+    items: TransactionItemSummary[];
+}
+
+interface CustomerDisplayProps {
+    transaction: TransactionSummary | null;
+    autoRefresh: boolean;
+    latestUrl: string;
+}
+
+const formatCurrency = (value: number) =>
+    new Intl.NumberFormat('id-ID', {
+        style: 'currency',
+        currency: 'IDR',
+        minimumFractionDigits: 2,
+    }).format(value);
+
+const formatDate = (value: string | null) => {
+    if (!value) {
+        return '';
+    }
+
+    return new Intl.DateTimeFormat('id-ID', {
+        dateStyle: 'medium',
+        timeStyle: 'short',
+    }).format(new Date(value));
+};
+
+export default function CustomerDisplay({ transaction, autoRefresh, latestUrl }: CustomerDisplayProps) {
+    useEffect(() => {
+        if (!autoRefresh) {
+            return;
+        }
+
+        const interval = window.setInterval(() => {
+            router.reload({ only: ['transaction'], preserveScroll: true, preserveState: true });
+        }, 5000);
+
+        return () => window.clearInterval(interval);
+    }, [autoRefresh]);
+
+    const handleManualRefresh = () => {
+        router.visit(latestUrl, {
+            only: ['transaction'],
+            preserveScroll: true,
+            preserveState: true,
+        });
+    };
+
+    return (
+        <CustomerLayout>
+            <Head title="Customer display" />
+
+            <div className="space-y-6">
+                <header className="space-y-1 text-center">
+                    <h1 className="text-4xl font-bold tracking-tight">Terima kasih telah berbelanja</h1>
+                    <p className="text-lg text-muted-foreground">
+                        Harap pastikan semua item sudah sesuai sebelum melakukan pembayaran.
+                    </p>
+                </header>
+
+                {autoRefresh && (
+                    <Alert className="border-blue-200 bg-blue-50 text-blue-900 dark:border-blue-900/40 dark:bg-blue-900/20 dark:text-blue-100">
+                        <AlertTitle>Tampilan pelanggan</AlertTitle>
+                        <AlertDescription>
+                            Layar ini diperbarui otomatis setiap 5 detik untuk menampilkan transaksi terbaru.
+                        </AlertDescription>
+                    </Alert>
+                )}
+
+                <div className="flex flex-wrap items-center justify-between gap-4">
+                    <div className="space-y-1 text-sm text-muted-foreground">
+                        {transaction ? (
+                            <>
+                                <div>
+                                    Nomor transaksi:{' '}
+                                    <span className="font-semibold text-foreground">
+                                        {transaction.number}
+                                    </span>
+                                </div>
+                                <div>Waktu: {formatDate(transaction.created_at)}</div>
+                                {transaction.user && <div>Kasir: {transaction.user.name}</div>}
+                            </>
+                        ) : (
+                            <div>Belum ada transaksi yang diselesaikan.</div>
+                        )}
+                    </div>
+
+                    <Button type="button" variant="outline" onClick={handleManualRefresh}>
+                        <RefreshCcw className="mr-2 h-4 w-4" />
+                        Muat ulang
+                    </Button>
+                </div>
+
+                {transaction ? (
+                    <div className="space-y-6">
+                        <div className="overflow-hidden rounded-xl border border-border bg-background">
+                            <table className="min-w-full divide-y divide-border text-lg">
+                                <thead className="bg-muted/50 text-base uppercase tracking-wide">
+                                    <tr>
+                                        <th className="px-6 py-4 text-left">Produk</th>
+                                        <th className="px-6 py-4 text-center">Jumlah</th>
+                                        <th className="px-6 py-4 text-right">Harga</th>
+                                        <th className="px-6 py-4 text-right">Total</th>
+                                    </tr>
+                                </thead>
+                                <tbody className="divide-y divide-border">
+                                    {transaction.items.map((item) => (
+                                        <tr key={item.id}>
+                                            <td className="px-6 py-4">
+                                                <div className="text-xl font-semibold">{item.name}</div>
+                                                <div className="text-sm text-muted-foreground">{item.barcode}</div>
+                                            </td>
+                                            <td className="px-6 py-4 text-center font-medium">{item.quantity}</td>
+                                            <td className="px-6 py-4 text-right">{formatCurrency(item.unit_price)}</td>
+                                            <td className="px-6 py-4 text-right font-semibold">
+                                                {formatCurrency(item.line_total)}
+                                            </td>
+                                        </tr>
+                                    ))}
+                                </tbody>
+                            </table>
+                        </div>
+
+                        <div className="space-y-3 rounded-xl border border-border bg-background p-6 text-2xl">
+                            <div className="flex items-center justify-between">
+                                <span>Subtotal</span>
+                                <span>{formatCurrency(transaction.subtotal)}</span>
+                            </div>
+                            <div className="flex items-center justify-between">
+                                <span>PPN ({transaction.ppn_rate}%)</span>
+                                <span>{formatCurrency(transaction.tax_total)}</span>
+                            </div>
+                            <div className="flex items-center justify-between text-3xl font-bold">
+                                <span>Total Pembayaran</span>
+                                <span>{formatCurrency(transaction.total)}</span>
+                            </div>
+                        </div>
+                    </div>
+                ) : (
+                    <div className="rounded-xl border border-dashed border-border bg-background/60 p-12 text-center">
+                        <h2 className="text-2xl font-semibold">Menunggu transaksi berikutnya</h2>
+                        <p className="mt-2 text-base text-muted-foreground">
+                            Setelah kasir menyelesaikan transaksi, detail belanja Anda akan muncul di layar ini.
+                        </p>
+                    </div>
+                )}
+            </div>
+        </CustomerLayout>
+    );
+}

--- a/resources/js/pages/transactions/employee.tsx
+++ b/resources/js/pages/transactions/employee.tsx
@@ -1,0 +1,525 @@
+import InputError from '@/components/input-error';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import AppLayout from '@/layouts/app-layout';
+import { type SharedData } from '@/types';
+import { Head, useForm, usePage } from '@inertiajs/react';
+import { BrowserMultiFormatReader } from '@zxing/browser';
+import { FormEvent, useEffect, useMemo, useRef, useState } from 'react';
+import { Minus, Plus, RefreshCcw, ScanLine, Trash2 } from 'lucide-react';
+
+interface TransactionProduct {
+    id: number;
+    barcode: string;
+    name: string;
+    price: number;
+}
+
+interface EmployeeTransactionsPageProps {
+    ppnRate: number;
+    productLookupUrl: string;
+    storeUrl: string;
+    recentTransactionId?: number | null;
+    customerBaseUrl: string;
+    customerLatestUrl: string;
+}
+
+interface CartItem extends TransactionProduct {
+    quantity: number;
+}
+
+const formatCurrency = (value: number) =>
+    new Intl.NumberFormat('id-ID', {
+        style: 'currency',
+        currency: 'IDR',
+        minimumFractionDigits: 2,
+    }).format(value);
+
+const buildUrl = (template: string, placeholder: string, value: string | number) =>
+    template.replace(placeholder, encodeURIComponent(String(value)));
+
+export default function EmployeeTransactions({
+    ppnRate,
+    productLookupUrl,
+    storeUrl,
+    recentTransactionId,
+    customerBaseUrl,
+    customerLatestUrl,
+}: EmployeeTransactionsPageProps) {
+    const { flash } = usePage<SharedData>().props;
+    const [items, setItems] = useState<CartItem[]>([]);
+    const [manualBarcode, setManualBarcode] = useState('');
+    const [scannerEnabled, setScannerEnabled] = useState(false);
+    const [scanError, setScanError] = useState<string | null>(null);
+    const [lookupError, setLookupError] = useState<string | null>(null);
+    const [isLookingUp, setIsLookingUp] = useState(false);
+    const videoRef = useRef<HTMLVideoElement | null>(null);
+    const readerRef = useRef<BrowserMultiFormatReader | null>(null);
+    const processedBarcodesRef = useRef<Set<string>>(new Set());
+
+    const form = useForm<{ items: { product_id: number; quantity: number }[] }>({
+        items: [],
+    });
+
+    const totals = useMemo(() => {
+        const subtotal = items.reduce(
+            (total, item) => total + item.price * item.quantity,
+            0,
+        );
+        const tax = subtotal * (ppnRate / 100);
+        const total = subtotal + tax;
+
+        return {
+            subtotal,
+            tax,
+            total,
+        };
+    }, [items, ppnRate]);
+
+    const customerUrl =
+        recentTransactionId != null
+            ? buildUrl(customerBaseUrl, '__ID__', recentTransactionId)
+            : null;
+
+    useEffect(() => {
+        if (!scannerEnabled) {
+            cleanupScanner();
+            return;
+        }
+
+        if (!videoRef.current) {
+            return;
+        }
+
+        const reader = new BrowserMultiFormatReader();
+        readerRef.current = reader;
+        setScanError(null);
+
+        reader
+            .decodeFromVideoDevice(
+                undefined,
+                videoRef.current,
+                (result, error) => {
+                    if (result) {
+                        const text = result.getText();
+                        if (text && !processedBarcodesRef.current.has(text)) {
+                            processedBarcodesRef.current.add(text);
+                            handleProductLookup(text);
+                            setTimeout(
+                                () => processedBarcodesRef.current.delete(text),
+                                1000,
+                            );
+                        }
+                    }
+
+                    if (error && !('name' in error && error.name === 'NotFoundException')) {
+                        setScanError('Unable to read barcode. Try adjusting the camera.');
+                    }
+                },
+            )
+            .catch(() => {
+                setScanError('Camera access was denied or not available.');
+                cleanupScanner();
+                setScannerEnabled(false);
+            });
+
+        return () => {
+            cleanupScanner();
+        };
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [scannerEnabled]);
+
+    const cleanupScanner = () => {
+        readerRef.current?.reset();
+        readerRef.current = null;
+
+        const stream = videoRef.current?.srcObject;
+        if (stream instanceof MediaStream) {
+            stream.getTracks().forEach((track) => track.stop());
+        }
+
+        if (videoRef.current) {
+            videoRef.current.srcObject = null;
+        }
+    };
+
+    const handleProductLookup = async (barcode: string) => {
+        const trimmed = barcode.trim();
+        if (!trimmed) {
+            return;
+        }
+
+        setLookupError(null);
+        setIsLookingUp(true);
+
+        try {
+            const response = await fetch(
+                buildUrl(productLookupUrl, '__BARCODE__', trimmed),
+                {
+                    headers: {
+                        Accept: 'application/json',
+                    },
+                },
+            );
+
+            if (!response.ok) {
+                setLookupError('Product not found for the provided barcode.');
+                return;
+            }
+
+            const data = (await response.json()) as TransactionProduct;
+            addProductToCart(data);
+        } catch (error) {
+            console.error(error);
+            setLookupError('Unable to fetch product details. Please try again.');
+        } finally {
+            setIsLookingUp(false);
+        }
+    };
+
+    const addProductToCart = (product: TransactionProduct) => {
+        setItems((current) => {
+            const existing = current.find((item) => item.id === product.id);
+
+            if (existing) {
+                return current.map((item) =>
+                    item.id === product.id
+                        ? { ...item, quantity: item.quantity + 1 }
+                        : item,
+                );
+            }
+
+            return [
+                ...current,
+                {
+                    ...product,
+                    quantity: 1,
+                },
+            ];
+        });
+
+        setManualBarcode('');
+        setLookupError(null);
+    };
+
+    const handleManualSubmit = (event: FormEvent<HTMLFormElement>) => {
+        event.preventDefault();
+        if (!manualBarcode.trim()) {
+            setLookupError('Enter a barcode to look up a product.');
+            return;
+        }
+
+        handleProductLookup(manualBarcode);
+    };
+
+    const handleQuantityChange = (productId: number, quantity: number) => {
+        if (Number.isNaN(quantity) || quantity < 1) {
+            return;
+        }
+
+        setItems((current) =>
+            current.map((item) =>
+                item.id === productId
+                    ? { ...item, quantity: Math.floor(quantity) }
+                    : item,
+            ),
+        );
+    };
+
+    const handleIncrement = (productId: number) => {
+        setItems((current) =>
+            current.map((item) =>
+                item.id === productId
+                    ? { ...item, quantity: item.quantity + 1 }
+                    : item,
+            ),
+        );
+    };
+
+    const handleDecrement = (productId: number) => {
+        setItems((current) =>
+            current.map((item) =>
+                item.id === productId && item.quantity > 1
+                    ? { ...item, quantity: item.quantity - 1 }
+                    : item,
+            ),
+        );
+    };
+
+    const handleRemove = (productId: number) => {
+        setItems((current) => current.filter((item) => item.id !== productId));
+    };
+
+    const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+        event.preventDefault();
+
+        if (items.length === 0) {
+            form.setError('items', 'Add at least one product before saving.');
+            return;
+        }
+
+        form.setData(
+            'items',
+            items.map((item) => ({
+                product_id: item.id,
+                quantity: item.quantity,
+            })),
+        );
+
+        form.post(storeUrl, {
+            preserveScroll: true,
+            onSuccess: () => {
+                setItems([]);
+                form.reset();
+            },
+        });
+    };
+
+    useEffect(() => () => cleanupScanner(), []);
+
+    return (
+        <AppLayout>
+            <Head title="Point of Sale" />
+
+            <div className="space-y-6 p-4">
+                <div className="flex items-start justify-between gap-4">
+                    <div>
+                        <h1 className="text-2xl font-semibold">Employee POS</h1>
+                        <p className="text-sm text-muted-foreground">
+                            Scan product barcodes or search manually to build a transaction.
+                        </p>
+                        <p className="mt-2 text-sm text-muted-foreground">
+                            Current PPN rate: <span className="font-medium">{ppnRate}%</span>
+                        </p>
+                    </div>
+                    <div className="flex flex-col items-end gap-2 text-right text-sm">
+                        <Button
+                            type="button"
+                            variant={scannerEnabled ? 'secondary' : 'default'}
+                            onClick={() => setScannerEnabled((value) => !value)}
+                        >
+                            <ScanLine className="mr-2 h-4 w-4" />
+                            {scannerEnabled ? 'Stop scanner' : 'Start scanner'}
+                        </Button>
+                        <Button
+                            type="button"
+                            variant="outline"
+                            onClick={() => handleProductLookup(manualBarcode)}
+                            disabled={isLookingUp || !manualBarcode.trim()}
+                        >
+                            <RefreshCcw className="mr-2 h-4 w-4" />
+                            Refresh lookup
+                        </Button>
+                    </div>
+                </div>
+
+                {flash?.success && (
+                    <Alert className="border-green-200 bg-green-50 text-green-900 dark:border-green-900/40 dark:bg-green-900/20 dark:text-green-100">
+                        <AlertTitle>Success</AlertTitle>
+                        <AlertDescription>{flash.success}</AlertDescription>
+                    </Alert>
+                )}
+
+                {customerUrl && (
+                    <Alert>
+                        <AlertTitle>Customer display ready</AlertTitle>
+                        <AlertDescription>
+                            <a
+                                href={customerUrl}
+                                className="font-medium text-primary hover:underline"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                            >
+                                Open the latest receipt for your customer
+                            </a>
+                            . You can also monitor the live display at{' '}
+                            <a
+                                href={customerLatestUrl}
+                                className="font-medium text-primary hover:underline"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                            >
+                                /transactions/customer/latest
+                            </a>
+                            .
+                        </AlertDescription>
+                    </Alert>
+                )}
+
+                {scanError && (
+                    <Alert className="border-yellow-200 bg-yellow-50 text-yellow-800 dark:border-yellow-900/50 dark:bg-yellow-900/20 dark:text-yellow-100">
+                        <AlertTitle>Scanner notice</AlertTitle>
+                        <AlertDescription>{scanError}</AlertDescription>
+                    </Alert>
+                )}
+
+                {lookupError && (
+                    <Alert className="border-red-200 bg-red-50 text-red-900 dark:border-red-900/40 dark:bg-red-900/20 dark:text-red-100">
+                        <AlertTitle>Lookup error</AlertTitle>
+                        <AlertDescription>{lookupError}</AlertDescription>
+                    </Alert>
+                )}
+
+                <div className="grid gap-6 lg:grid-cols-[2fr_1fr]">
+                    <div className="space-y-6">
+                        <Card className="p-4">
+                            <form className="space-y-4" onSubmit={handleManualSubmit}>
+                                <div className="grid gap-2 md:grid-cols-[1fr_auto] md:items-end">
+                                    <div className="space-y-2">
+                                        <Label htmlFor="barcode">Manual barcode entry</Label>
+                                        <Input
+                                            id="barcode"
+                                            value={manualBarcode}
+                                            placeholder="Scan or type a barcode"
+                                            onChange={(event) => setManualBarcode(event.target.value)}
+                                        />
+                                    </div>
+                                    <Button type="submit" className="w-full md:w-auto" disabled={isLookingUp}>
+                                        Add product
+                                    </Button>
+                                </div>
+                            </form>
+                        </Card>
+
+                        {scannerEnabled && (
+                            <Card className="overflow-hidden">
+                                <div className="bg-muted p-4">
+                                    <video
+                                        ref={videoRef}
+                                        className="h-64 w-full rounded-lg object-cover"
+                                        autoPlay
+                                        playsInline
+                                        muted
+                                    />
+                                </div>
+                            </Card>
+                        )}
+
+                        <Card className="overflow-hidden">
+                            <div className="overflow-x-auto">
+                                <table className="min-w-full divide-y divide-border text-sm">
+                                    <thead className="bg-muted/50">
+                                        <tr>
+                                            <th className="px-4 py-3 text-left font-medium">Product</th>
+                                            <th className="px-4 py-3 text-left font-medium">Price</th>
+                                            <th className="px-4 py-3 text-left font-medium">Quantity</th>
+                                            <th className="px-4 py-3 text-left font-medium">Line total</th>
+                                            <th className="px-4 py-3 text-right font-medium">Actions</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody className="divide-y divide-border">
+                                        {items.length === 0 ? (
+                                            <tr>
+                                                <td colSpan={5} className="px-4 py-6 text-center text-muted-foreground">
+                                                    Scan a barcode or add a product manually to begin.
+                                                </td>
+                                            </tr>
+                                        ) : (
+                                            items.map((item) => {
+                                                const lineTotal = item.price * item.quantity;
+
+                                                return (
+                                                    <tr key={item.id}>
+                                                        <td className="px-4 py-3">
+                                                            <div className="font-medium">{item.name}</div>
+                                                            <div className="text-xs text-muted-foreground">{item.barcode}</div>
+                                                        </td>
+                                                        <td className="px-4 py-3">{formatCurrency(item.price)}</td>
+                                                        <td className="px-4 py-3">
+                                                            <div className="flex items-center gap-2">
+                                                                <Button
+                                                                    type="button"
+                                                                    size="icon"
+                                                                    variant="outline"
+                                                                    onClick={() => handleDecrement(item.id)}
+                                                                    disabled={item.quantity <= 1}
+                                                                >
+                                                                    <Minus className="h-4 w-4" />
+                                                                </Button>
+                                                                <Input
+                                                                    type="number"
+                                                                    min={1}
+                                                                    className="w-20"
+                                                                    value={item.quantity}
+                                                                    onChange={(event) =>
+                                                                        handleQuantityChange(
+                                                                            item.id,
+                                                                            Number.parseInt(event.target.value, 10),
+                                                                        )
+                                                                    }
+                                                                />
+                                                                <Button
+                                                                    type="button"
+                                                                    size="icon"
+                                                                    variant="outline"
+                                                                    onClick={() => handleIncrement(item.id)}
+                                                                >
+                                                                    <Plus className="h-4 w-4" />
+                                                                </Button>
+                                                            </div>
+                                                        </td>
+                                                        <td className="px-4 py-3">{formatCurrency(lineTotal)}</td>
+                                                        <td className="px-4 py-3 text-right">
+                                                            <Button
+                                                                type="button"
+                                                                variant="destructive"
+                                                                size="icon"
+                                                                onClick={() => handleRemove(item.id)}
+                                                            >
+                                                                <Trash2 className="h-4 w-4" />
+                                                            </Button>
+                                                        </td>
+                                                    </tr>
+                                                );
+                                            })
+                                        )}
+                                    </tbody>
+                                </table>
+                            </div>
+                        </Card>
+                    </div>
+
+                    <div className="space-y-6">
+                        <Card className="space-y-4 p-4">
+                            <h2 className="text-lg font-semibold">Transaction summary</h2>
+                            <div className="space-y-2 text-sm">
+                                <div className="flex items-center justify-between">
+                                    <span>Subtotal</span>
+                                    <span className="font-medium">{formatCurrency(totals.subtotal)}</span>
+                                </div>
+                                <div className="flex items-center justify-between">
+                                    <span>PPN ({ppnRate}%)</span>
+                                    <span className="font-medium">{formatCurrency(totals.tax)}</span>
+                                </div>
+                                <div className="flex items-center justify-between text-base font-semibold">
+                                    <span>Total</span>
+                                    <span>{formatCurrency(totals.total)}</span>
+                                </div>
+                            </div>
+                        </Card>
+
+                        <Card className="p-4">
+                            <form className="space-y-4" onSubmit={handleSubmit}>
+                                <div>
+                                    <h3 className="text-lg font-semibold">Finalize sale</h3>
+                                    <p className="text-sm text-muted-foreground">
+                                        Confirm the items to record this transaction and update stock levels.
+                                    </p>
+                                </div>
+
+                                <InputError message={form.errors.items} />
+
+                                <Button type="submit" className="w-full" disabled={form.processing || items.length === 0}>
+                                    Complete transaction
+                                </Button>
+                            </form>
+                        </Card>
+                    </div>
+                </div>
+            </div>
+        </AppLayout>
+    );
+}

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -2,7 +2,7 @@ import { InertiaLinkProps } from '@inertiajs/react';
 import { LucideIcon } from 'lucide-react';
 
 export interface Auth {
-    user: User;
+    user: User | null;
 }
 
 export interface BreadcrumbItem {
@@ -43,5 +43,7 @@ export interface User {
     two_factor_enabled?: boolean;
     created_at: string;
     updated_at: string;
+    permissions?: string[];
+    roles?: string[];
     [key: string]: unknown; // This allows for additional properties...
 }

--- a/routes/settings.php
+++ b/routes/settings.php
@@ -2,6 +2,7 @@
 
 use App\Http\Controllers\Settings\PasswordController;
 use App\Http\Controllers\Settings\ProfileController;
+use App\Http\Controllers\Settings\StoreSettingsController;
 use App\Http\Controllers\Settings\TwoFactorAuthenticationController;
 use Illuminate\Support\Facades\Route;
 use Inertia\Inertia;
@@ -22,6 +23,14 @@ Route::middleware('auth')->group(function () {
     Route::get('settings/appearance', function () {
         return Inertia::render('settings/appearance');
     })->name('appearance.edit');
+
+    Route::get('settings/store', [StoreSettingsController::class, 'edit'])
+        ->middleware('can:manage settings')
+        ->name('store.edit');
+
+    Route::put('settings/store', [StoreSettingsController::class, 'update'])
+        ->middleware('can:manage settings')
+        ->name('store.update');
 
     Route::get('settings/two-factor', [TwoFactorAuthenticationController::class, 'show'])
         ->name('two-factor.show');

--- a/routes/web.php
+++ b/routes/web.php
@@ -4,6 +4,7 @@ use App\Http\Controllers\Master\PermissionController;
 use App\Http\Controllers\Master\ProductController;
 use App\Http\Controllers\Master\RoleController;
 use App\Http\Controllers\Master\UserController;
+use App\Http\Controllers\Transactions\TransactionController;
 use Illuminate\Support\Facades\Route;
 use Inertia\Inertia;
 
@@ -15,6 +16,14 @@ Route::middleware(['auth', 'verified'])->group(function () {
     Route::get('dashboard', function () {
         return Inertia::render('dashboard');
     })->name('dashboard');
+
+    Route::prefix('transactions')->name('transactions.')->group(function () {
+        Route::get('employee', [TransactionController::class, 'employee'])->name('employee');
+        Route::post('/', [TransactionController::class, 'store'])->name('store');
+        Route::get('products/{product:barcode}', [TransactionController::class, 'showProduct'])->name('products.show');
+        Route::get('customer/latest', [TransactionController::class, 'latest'])->name('customer.latest');
+        Route::get('customer/{transaction}', [TransactionController::class, 'customer'])->name('customer');
+    });
 
     Route::prefix('master')->name('master.')->group(function () {
         Route::resource('roles', RoleController::class)->except(['create', 'edit', 'show']);


### PR DESCRIPTION
## Summary
- add transaction, transaction item, and store setting models, migrations, and controllers to support checkout storage and tax configuration
- build an employee POS page with barcode scanning, cart management, and transaction submission plus a customer display view for recent receipts
- expose store PPN settings only to administrators and surface the new workflows in navigation while sharing user permissions with Inertia