### PR TITLE
Add product category management

### DIFF
--- a/app/Exports/ProductsExport.php
+++ b/app/Exports/ProductsExport.php
@@ -16,6 +16,7 @@ class ProductsExport implements FromCollection, WithHeadings, WithMapping
     public function collection(): Collection
     {
         return Product::query()
+            ->with('categories')
             ->orderByDesc('created_at')
             ->get();
     }
@@ -33,6 +34,10 @@ class ProductsExport implements FromCollection, WithHeadings, WithMapping
             $product->stock,
             $product->price,
             $product->image_path,
+            $product->categories
+                ->sortBy('name')
+                ->pluck('name')
+                ->implode(', '),
         ];
     }
 
@@ -41,6 +46,6 @@ class ProductsExport implements FromCollection, WithHeadings, WithMapping
      */
     public function headings(): array
     {
-        return ['id', 'barcode', 'name', 'stock', 'price', 'image_path'];
+        return ['id', 'barcode', 'name', 'stock', 'price', 'image_path', 'categories'];
     }
 }

--- a/app/Http/Requests/Master/StoreProductRequest.php
+++ b/app/Http/Requests/Master/StoreProductRequest.php
@@ -28,6 +28,8 @@ class StoreProductRequest extends FormRequest
             'stock' => ['required', 'integer', 'min:0'],
             'price' => ['required', 'numeric', 'min:0'],
             'image' => ['nullable', 'image', 'max:5120'],
+            'category_ids' => ['nullable', 'array'],
+            'category_ids.*' => ['integer', Rule::exists('categories', 'id')],
         ];
     }
 }

--- a/app/Http/Requests/Master/UpdateProductRequest.php
+++ b/app/Http/Requests/Master/UpdateProductRequest.php
@@ -38,6 +38,8 @@ class UpdateProductRequest extends FormRequest
             'price' => ['required', 'numeric', 'min:0'],
             'image' => ['nullable', 'image', 'max:5120'],
             'remove_image' => ['sometimes', 'boolean'],
+            'category_ids' => ['sometimes', 'array'],
+            'category_ids.*' => ['integer', Rule::exists('categories', 'id')],
         ];
     }
 }

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+
+class Category extends Model
+{
+    use HasFactory;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'name',
+    ];
+
+    /**
+     * The products that belong to the category.
+     */
+    public function products(): BelongsToMany
+    {
+        return $this->belongsToMany(Product::class)->withTimestamps();
+    }
+}

--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 
 class Product extends Model
 {
@@ -31,4 +32,12 @@ class Product extends Model
         'stock' => 'integer',
         'price' => 'decimal:2',
     ];
+
+    /**
+     * The categories that belong to the product.
+     */
+    public function categories(): BelongsToMany
+    {
+        return $this->belongsToMany(Category::class)->withTimestamps();
+    }
 }

--- a/database/factories/CategoryFactory.php
+++ b/database/factories/CategoryFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Category;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Category>
+ */
+class CategoryFactory extends Factory
+{
+    protected $model = Category::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'name' => $this->faker->unique()->words(2, true),
+        ];
+    }
+}

--- a/database/migrations/2025_09_30_090000_create_categories_table.php
+++ b/database/migrations/2025_09_30_090000_create_categories_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('categories', function (Blueprint $table): void {
+            $table->id();
+            $table->string('name')->unique();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('categories');
+    }
+};

--- a/database/migrations/2025_09_30_090001_create_category_product_table.php
+++ b/database/migrations/2025_09_30_090001_create_category_product_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('category_product', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('category_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('product_id')->constrained()->cascadeOnDelete();
+            $table->timestamps();
+
+            $table->unique(['category_id', 'product_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('category_product');
+    }
+};

--- a/tests/Feature/Master/ProductCategoryTest.php
+++ b/tests/Feature/Master/ProductCategoryTest.php
@@ -1,0 +1,132 @@
+<?php
+
+use App\Exports\ProductsExport;
+use App\Imports\ProductsImport;
+use App\Models\Category;
+use App\Models\Product;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Collection;
+
+uses(RefreshDatabase::class);
+
+test('products can be created with categories', function () {
+    $user = User::factory()->create();
+    $categories = Category::factory()->count(3)->create();
+
+    $response = $this
+        ->actingAs($user)
+        ->from('/master/products')
+        ->post('/master/products', [
+            'barcode' => 'CAT-100',
+            'name' => 'Category aware product',
+            'stock' => 15,
+            'price' => 49.99,
+            'category_ids' => $categories->take(2)->pluck('id')->all(),
+        ]);
+
+    $response
+        ->assertSessionHasNoErrors()
+        ->assertRedirect('/master/products');
+
+    $product = Product::where('barcode', 'CAT-100')->firstOrFail();
+
+    expect($product->categories()->pluck('categories.id')->all())
+        ->toBe($categories->take(2)->pluck('id')->all());
+});
+
+test('products can be updated with categories', function () {
+    $user = User::factory()->create();
+    $initialCategories = Category::factory()->count(2)->create();
+    $product = Product::create([
+        'barcode' => 'CAT-200',
+        'name' => 'Updatable product',
+        'stock' => 5,
+        'price' => 15.5,
+    ]);
+    $product->categories()->sync($initialCategories->pluck('id'));
+
+    $newCategories = Category::factory()->count(2)->create();
+
+    $response = $this
+        ->actingAs($user)
+        ->from('/master/products')
+        ->put("/master/products/{$product->id}", [
+            'barcode' => 'CAT-200',
+            'name' => 'Updatable product',
+            'stock' => 20,
+            'price' => 25.0,
+            'remove_image' => false,
+            'category_ids' => [
+                $initialCategories->last()->id,
+                $newCategories->first()->id,
+            ],
+        ]);
+
+    $response
+        ->assertSessionHasNoErrors()
+        ->assertRedirect('/master/products');
+
+    $product->refresh();
+
+    expect($product->categories()->pluck('categories.id')->all())
+        ->toBe([
+            $initialCategories->last()->id,
+            $newCategories->first()->id,
+        ]);
+});
+
+test('products import maps categories from the spreadsheet', function () {
+    Category::factory()->create(['name' => 'Electronics']);
+    $import = new ProductsImport();
+
+    $rows = new Collection([
+        new Collection([
+            'barcode' => 'IMP-100',
+            'name' => 'Imported product',
+            'stock' => 3,
+            'price' => 9.99,
+            'categories' => 'Electronics, Gadgets | Accessories; Gadgets',
+        ]),
+    ]);
+
+    $import->collection($rows);
+
+    $product = Product::where('barcode', 'IMP-100')->firstOrFail();
+
+    expect($product->categories()->pluck('name')->sort()->values()->all())
+        ->toBe([
+            'Accessories',
+            'Electronics',
+            'Gadgets',
+        ]);
+    expect(Category::where('name', 'Electronics')->count())->toBe(1);
+    expect($import->importedCount())->toBe(1);
+});
+
+test('products export includes category names', function () {
+    $product = Product::create([
+        'barcode' => 'EXP-100',
+        'name' => 'Exportable product',
+        'stock' => 12,
+        'price' => 19.5,
+    ]);
+
+    $categories = Category::factory()->count(2)->create();
+
+    $product->categories()->sync($categories->pluck('id'));
+
+    $export = new ProductsExport();
+    $row = $export->map($product->load('categories'));
+
+    expect($export->headings())
+        ->toBe(['id', 'barcode', 'name', 'stock', 'price', 'image_path', 'categories']);
+    expect($row[6])
+        ->toBe(
+            $categories
+                ->pluck('name')
+                ->sort()
+                ->values()
+                ->implode(', '),
+        );
+});


### PR DESCRIPTION
## Summary
- add category schema, model, factory, and product relationship for tagging products
- sync category assignments through validation, controller, and import/export workflows
- surface categories in the product UI with multi-select controls and new integration coverage

## Testing
- php artisan test --filter=ProductCategoryTest

------
https://chatgpt.com/codex/tasks/task_e_68dba4922100832fad3b6d2268d49cd2