### PR TITLE
Add metrics-driven dashboard

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Product;
+use App\Models\Transaction;
+use App\Models\TransactionItem;
+use Carbon\CarbonImmutable;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class DashboardController extends Controller
+{
+    public function __invoke(Request $request): Response
+    {
+        $defaultDays = (int) config('store.dashboard.default_range_days', 14);
+        $maxDays = (int) config('store.dashboard.max_range_days', 90);
+        $days = (int) max(1, min($maxDays, $request->integer('days', $defaultDays)));
+        $cacheMinutes = (int) config('store.dashboard.cache_minutes', 5);
+        $cacheKey = sprintf('dashboard:metrics:%d', $days);
+
+        $metrics = Cache::remember(
+            $cacheKey,
+            now()->addMinutes($cacheMinutes),
+            function () use ($days) {
+                $end = CarbonImmutable::now()->endOfDay();
+                $start = $end->subDays($days - 1)->startOfDay();
+
+                $aggregate = Transaction::query()
+                    ->withinPeriod($start, $end)
+                    ->selectRaw('SUM(total) as revenue')
+                    ->selectRaw('COUNT(*) as transactions')
+                    ->selectRaw('SUM(items_count) as items')
+                    ->first();
+
+                $revenue = (float) ($aggregate?->revenue ?? 0);
+                $transactions = (int) ($aggregate?->transactions ?? 0);
+                $items = (int) ($aggregate?->items ?? 0);
+                $averageBasket = $transactions > 0 ? round($items / $transactions, 2) : 0.0;
+
+                $dailySales = Transaction::query()
+                    ->withinPeriod($start, $end)
+                    ->dailyBreakdown()
+                    ->get()
+                    ->map(static function ($row) {
+                        $transactions = (int) $row->transactions;
+                        $items = (int) $row->items;
+
+                        return [
+                            'date' => $row->date,
+                            'revenue' => (float) $row->revenue,
+                            'transactions' => $transactions,
+                            'items' => $items,
+                            'averageBasketSize' => $transactions > 0
+                                ? round($items / $transactions, 2)
+                                : 0.0,
+                        ];
+                    })
+                    ->values()
+                    ->all();
+
+                $topSelling = TransactionItem::query()
+                    ->whereHas('transaction', static function ($query) use ($start, $end) {
+                        $query->withinPeriod($start, $end);
+                    })
+                    ->topSelling()
+                    ->get()
+                    ->map(static function ($row) {
+                        return [
+                            'name' => $row->name,
+                            'quantity' => (int) $row->quantity,
+                            'revenue' => (float) $row->revenue,
+                        ];
+                    })
+                    ->values()
+                    ->all();
+
+                $lowStockThreshold = (int) config('store.inventory.low_stock_threshold', 10);
+                $lowStockCount = Product::query()
+                    ->where('stock', '<=', $lowStockThreshold)
+                    ->count();
+
+                return [
+                    'totals' => [
+                        'revenue' => $revenue,
+                        'transactions' => $transactions,
+                        'itemsSold' => $items,
+                        'averageBasketSize' => $averageBasket,
+                        'lowStockCount' => $lowStockCount,
+                    ],
+                    'dailySales' => $dailySales,
+                    'topSelling' => $topSelling,
+                    'lowStockThreshold' => $lowStockThreshold,
+                    'currency' => config('app.currency', 'IDR'),
+                    'lastUpdated' => CarbonImmutable::now()->toIso8601String(),
+                    'range' => [
+                        'start' => $start->toDateString(),
+                        'end' => $end->toDateString(),
+                        'days' => $days,
+                    ],
+                ];
+            }
+        );
+
+        return Inertia::render('dashboard', [
+            'metrics' => $metrics,
+        ]);
+    }
+}

--- a/app/Models/Transaction.php
+++ b/app/Models/Transaction.php
@@ -2,6 +2,8 @@
 
 namespace App\Models;
 
+use Carbon\CarbonInterface;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -42,5 +44,21 @@ class Transaction extends Model
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class);
+    }
+
+    public function scopeWithinPeriod(Builder $query, CarbonInterface $start, CarbonInterface $end): Builder
+    {
+        return $query->whereBetween('created_at', [$start, $end]);
+    }
+
+    public function scopeDailyBreakdown(Builder $query): Builder
+    {
+        return $query
+            ->selectRaw('DATE(created_at) as date')
+            ->selectRaw('SUM(total) as revenue')
+            ->selectRaw('COUNT(*) as transactions')
+            ->selectRaw('SUM(items_count) as items')
+            ->groupByRaw('DATE(created_at)')
+            ->orderBy('date');
     }
 }

--- a/app/Models/TransactionItem.php
+++ b/app/Models/TransactionItem.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -44,5 +45,16 @@ class TransactionItem extends Model
     public function product(): BelongsTo
     {
         return $this->belongsTo(Product::class);
+    }
+
+    public function scopeTopSelling(Builder $query, int $limit = 5): Builder
+    {
+        return $query
+            ->select('product_id', 'name')
+            ->selectRaw('SUM(quantity) as quantity')
+            ->selectRaw('SUM(line_total) as revenue')
+            ->groupBy('product_id', 'name')
+            ->orderByDesc('quantity')
+            ->limit($limit);
     }
 }

--- a/config/store.php
+++ b/config/store.php
@@ -1,0 +1,12 @@
+<?php
+
+return [
+    'dashboard' => [
+        'default_range_days' => 14,
+        'max_range_days' => 90,
+        'cache_minutes' => 5,
+    ],
+    'inventory' => [
+        'low_stock_threshold' => 10,
+    ],
+];

--- a/resources/js/pages/dashboard.tsx
+++ b/resources/js/pages/dashboard.tsx
@@ -1,8 +1,48 @@
-import { PlaceholderPattern } from '@/components/ui/placeholder-pattern';
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import AppLayout from '@/layouts/app-layout';
 import { dashboard } from '@/routes';
 import { type BreadcrumbItem } from '@/types';
 import { Head } from '@inertiajs/react';
+import { BarChart3, PackageOpen, ShoppingBag, TrendingUp } from 'lucide-react';
+
+interface DailySalesSnapshot {
+    date: string;
+    revenue: number;
+    transactions: number;
+    items: number;
+    averageBasketSize: number;
+}
+
+interface TopSellingItem {
+    name: string;
+    quantity: number;
+    revenue: number;
+}
+
+interface DashboardMetrics {
+    totals: {
+        revenue: number;
+        transactions: number;
+        itemsSold: number;
+        averageBasketSize: number;
+        lowStockCount: number;
+    };
+    dailySales: DailySalesSnapshot[];
+    topSelling: TopSellingItem[];
+    lowStockThreshold: number;
+    currency: string;
+    lastUpdated: string;
+    range: {
+        start: string;
+        end: string;
+        days: number;
+    };
+}
+
+interface DashboardPageProps {
+    metrics: DashboardMetrics;
+}
 
 const breadcrumbs: BreadcrumbItem[] = [
     {
@@ -11,25 +51,313 @@ const breadcrumbs: BreadcrumbItem[] = [
     },
 ];
 
-export default function Dashboard() {
+const formatDate = (value: string, options?: Intl.DateTimeFormatOptions) =>
+    new Intl.DateTimeFormat('id-ID', options ?? { dateStyle: 'medium' }).format(new Date(value));
+
+const buildSparklinePoints = (values: number[]) => {
+    if (values.length === 0) {
+        return '';
+    }
+
+    if (values.length === 1) {
+        return '0,50 100,50';
+    }
+
+    const max = Math.max(...values);
+    const min = Math.min(...values);
+    const range = max - min || 1;
+
+    return values
+        .map((value, index) => {
+            const x = (index / (values.length - 1)) * 100;
+            const y = 100 - ((value - min) / range) * 100;
+            return `${x},${y}`;
+        })
+        .join(' ');
+};
+
+export default function Dashboard({ metrics }: DashboardPageProps) {
+    const dailySales = metrics.dailySales;
+    const revenueMax = dailySales.reduce((max, day) => Math.max(max, day.revenue), 0);
+    const formatCurrency = (value: number) =>
+        new Intl.NumberFormat('id-ID', {
+            style: 'currency',
+            currency: metrics.currency ?? 'IDR',
+            minimumFractionDigits: 0,
+        }).format(value);
+    const formatNumber = (value: number) => new Intl.NumberFormat('id-ID').format(value);
+
+    const periodLabel =
+        metrics.range.start === metrics.range.end
+            ? formatDate(metrics.range.start)
+            : `${formatDate(metrics.range.start)} – ${formatDate(metrics.range.end)}`;
+
+    const lastUpdatedLabel = formatDate(metrics.lastUpdated, {
+        dateStyle: 'medium',
+        timeStyle: 'short',
+    });
+
+    const averagePoints = buildSparklinePoints(
+        dailySales.map((day) => Number.isFinite(day.averageBasketSize) ? day.averageBasketSize : 0),
+    );
+
     return (
         <AppLayout breadcrumbs={breadcrumbs}>
             <Head title="Dashboard" />
-            <div className="flex h-full flex-1 flex-col gap-4 overflow-x-auto rounded-xl p-4">
-                <div className="grid auto-rows-min gap-4 md:grid-cols-3">
-                    <div className="relative aspect-video overflow-hidden rounded-xl border border-sidebar-border/70 dark:border-sidebar-border">
-                        <PlaceholderPattern className="absolute inset-0 size-full stroke-neutral-900/20 dark:stroke-neutral-100/20" />
-                    </div>
-                    <div className="relative aspect-video overflow-hidden rounded-xl border border-sidebar-border/70 dark:border-sidebar-border">
-                        <PlaceholderPattern className="absolute inset-0 size-full stroke-neutral-900/20 dark:stroke-neutral-100/20" />
-                    </div>
-                    <div className="relative aspect-video overflow-hidden rounded-xl border border-sidebar-border/70 dark:border-sidebar-border">
-                        <PlaceholderPattern className="absolute inset-0 size-full stroke-neutral-900/20 dark:stroke-neutral-100/20" />
-                    </div>
-                </div>
-                <div className="relative min-h-[100vh] flex-1 overflow-hidden rounded-xl border border-sidebar-border/70 md:min-h-min dark:border-sidebar-border">
-                    <PlaceholderPattern className="absolute inset-0 size-full stroke-neutral-900/20 dark:stroke-neutral-100/20" />
-                </div>
+
+            <div className="flex flex-1 flex-col gap-6 p-4">
+                <section className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+                    <Card>
+                        <CardHeader className="flex flex-row items-start justify-between space-y-0">
+                            <div>
+                                <CardTitle className="text-sm font-medium">Total Pendapatan</CardTitle>
+                                <CardDescription>Selama {metrics.range.days} hari terakhir</CardDescription>
+                            </div>
+                            <div className="rounded-full bg-primary/10 p-2 text-primary">
+                                <TrendingUp className="h-5 w-5" />
+                            </div>
+                        </CardHeader>
+                        <CardContent>
+                            <p className="text-3xl font-semibold tracking-tight">
+                                {formatCurrency(metrics.totals.revenue)}
+                            </p>
+                            <p className="mt-1 text-xs text-muted-foreground">Periode {periodLabel}</p>
+                        </CardContent>
+                    </Card>
+
+                    <Card>
+                        <CardHeader className="flex flex-row items-start justify-between space-y-0">
+                            <div>
+                                <CardTitle className="text-sm font-medium">Total Transaksi</CardTitle>
+                                <CardDescription>Termasuk {formatNumber(metrics.totals.itemsSold)} item</CardDescription>
+                            </div>
+                            <div className="rounded-full bg-primary/10 p-2 text-primary">
+                                <ShoppingBag className="h-5 w-5" />
+                            </div>
+                        </CardHeader>
+                        <CardContent>
+                            <p className="text-3xl font-semibold tracking-tight">
+                                {formatNumber(metrics.totals.transactions)}
+                            </p>
+                            <p className="mt-1 text-xs text-muted-foreground">Periode {periodLabel}</p>
+                        </CardContent>
+                    </Card>
+
+                    <Card>
+                        <CardHeader className="flex flex-row items-start justify-between space-y-0">
+                            <div>
+                                <CardTitle className="text-sm font-medium">Rata-rata Item per Keranjang</CardTitle>
+                                <CardDescription>Nilai rata-rata transaksi</CardDescription>
+                            </div>
+                            <div className="rounded-full bg-primary/10 p-2 text-primary">
+                                <BarChart3 className="h-5 w-5" />
+                            </div>
+                        </CardHeader>
+                        <CardContent>
+                            <p className="text-3xl font-semibold tracking-tight">
+                                {metrics.totals.averageBasketSize.toFixed(2)}
+                            </p>
+                            <p className="mt-1 text-xs text-muted-foreground">Diperbarui {lastUpdatedLabel}</p>
+                        </CardContent>
+                    </Card>
+
+                    <Card>
+                        <CardHeader className="flex flex-row items-start justify-between space-y-0">
+                            <div>
+                                <CardTitle className="text-sm font-medium">Produk Hampir Habis</CardTitle>
+                                <CardDescription>
+                                    Stok &le; {formatNumber(metrics.lowStockThreshold)}
+                                </CardDescription>
+                            </div>
+                            <div className="rounded-full bg-destructive/10 p-2 text-destructive">
+                                <PackageOpen className="h-5 w-5" />
+                            </div>
+                        </CardHeader>
+                        <CardContent>
+                            <p className="text-3xl font-semibold tracking-tight">
+                                {formatNumber(metrics.totals.lowStockCount)}
+                            </p>
+                            <p className="mt-1 text-xs text-muted-foreground">Periksa persediaan secara berkala</p>
+                        </CardContent>
+                    </Card>
+                </section>
+
+                <section className="grid gap-4 lg:grid-cols-3">
+                    <Card className="lg:col-span-2">
+                        <CardHeader>
+                            <CardTitle>Tren Penjualan Harian</CardTitle>
+                            <CardDescription>Performa pendapatan untuk periode {periodLabel}</CardDescription>
+                        </CardHeader>
+                        <CardContent>
+                            {dailySales.length > 0 ? (
+                                <div className="space-y-6">
+                                    <div className="flex h-56 items-end gap-3">
+                                        {dailySales.map((day) => {
+                                            const height = revenueMax > 0 ? (day.revenue / revenueMax) * 100 : 0;
+                                            return (
+                                                <div
+                                                    key={day.date}
+                                                    className="flex w-full flex-col items-center justify-end gap-2 text-center"
+                                                >
+                                                    <div className="flex h-full w-full items-end rounded-md bg-muted">
+                                                        <div
+                                                            className="w-full rounded-md rounded-b-none bg-primary/80"
+                                                            style={{ height: `${height}%` }}
+                                                        />
+                                                    </div>
+                                                    <div className="text-xs font-medium text-muted-foreground">
+                                                        {formatDate(day.date, { month: 'short', day: 'numeric' })}
+                                                    </div>
+                                                    <div className="text-xs text-foreground">
+                                                        {formatCurrency(day.revenue)}
+                                                    </div>
+                                                </div>
+                                            );
+                                        })}
+                                    </div>
+                                    <div className="grid gap-3 sm:grid-cols-3">
+                                        <div>
+                                            <p className="text-sm font-medium text-muted-foreground">Pendapatan rata-rata</p>
+                                            <p className="text-lg font-semibold">
+                                                {formatCurrency(
+                                                    revenueMax > 0
+                                                        ? dailySales.reduce((sum, day) => sum + day.revenue, 0) /
+                                                              dailySales.length
+                                                        : 0,
+                                                )}
+                                            </p>
+                                        </div>
+                                        <div>
+                                            <p className="text-sm font-medium text-muted-foreground">Transaksi harian</p>
+                                            <p className="text-lg font-semibold">
+                                                {(
+                                                    dailySales.reduce((sum, day) => sum + day.transactions, 0) /
+                                                    dailySales.length
+                                                ).toFixed(1)}
+                                            </p>
+                                        </div>
+                                        <div>
+                                            <p className="text-sm font-medium text-muted-foreground">Item terjual harian</p>
+                                            <p className="text-lg font-semibold">
+                                                {(
+                                                    dailySales.reduce((sum, day) => sum + day.items, 0) /
+                                                    dailySales.length
+                                                ).toFixed(1)}
+                                            </p>
+                                        </div>
+                                    </div>
+                                </div>
+                            ) : (
+                                <p className="text-sm text-muted-foreground">
+                                    Belum ada transaksi pada periode yang dipilih.
+                                </p>
+                            )}
+                        </CardContent>
+                    </Card>
+
+                    <Card>
+                        <CardHeader>
+                            <CardTitle>Produk Terlaris</CardTitle>
+                            <CardDescription>5 produk dengan penjualan terbaik</CardDescription>
+                        </CardHeader>
+                        <CardContent>
+                            {metrics.topSelling.length > 0 ? (
+                                <ul className="space-y-4">
+                                    {metrics.topSelling.map((item, index) => (
+                                        <li key={`${item.name}-${index}`} className="flex items-start justify-between gap-4">
+                                            <div>
+                                                <p className="font-medium leading-none">{item.name}</p>
+                                                <p className="text-xs text-muted-foreground">
+                                                    {formatNumber(item.quantity)} unit terjual
+                                                </p>
+                                            </div>
+                                            <div className="text-right">
+                                                <p className="text-sm font-semibold">{formatCurrency(item.revenue)}</p>
+                                                <p className="text-xs text-muted-foreground">Pendapatan</p>
+                                            </div>
+                                        </li>
+                                    ))}
+                                </ul>
+                            ) : (
+                                <p className="text-sm text-muted-foreground">
+                                    Belum ada produk terjual pada periode ini.
+                                </p>
+                            )}
+                        </CardContent>
+                    </Card>
+                </section>
+
+                <section className="grid gap-4 lg:grid-cols-3">
+                    <Card className="lg:col-span-2">
+                        <CardHeader>
+                            <CardTitle>Rata-rata Keranjang</CardTitle>
+                            <CardDescription>Pergerakan jumlah item rata-rata per transaksi</CardDescription>
+                        </CardHeader>
+                        <CardContent>
+                            {dailySales.length > 0 ? (
+                                <div className="space-y-4">
+                                    <div className="h-40 w-full overflow-hidden">
+                                        <svg
+                                            className="h-full w-full text-primary"
+                                            viewBox="0 0 100 100"
+                                            preserveAspectRatio="none"
+                                            role="img"
+                                            aria-label="Grafik rata-rata keranjang"
+                                        >
+                                            <polyline
+                                                fill="none"
+                                                stroke="currentColor"
+                                                strokeWidth={2}
+                                                points={averagePoints}
+                                            />
+                                        </svg>
+                                    </div>
+                                    <ul className="grid gap-3 sm:grid-cols-3">
+                                        {dailySales.slice(-3).map((day) => (
+                                            <li key={`avg-${day.date}`} className="rounded-lg border p-3">
+                                                <p className="text-xs text-muted-foreground">
+                                                    {formatDate(day.date, { weekday: 'short', day: 'numeric' })}
+                                                </p>
+                                                <p className="text-lg font-semibold">
+                                                    {day.averageBasketSize.toFixed(2)}
+                                                </p>
+                                                <p className="text-xs text-muted-foreground">
+                                                    {formatNumber(day.transactions)} transaksi •{' '}
+                                                    {formatNumber(day.items)} item
+                                                </p>
+                                            </li>
+                                        ))}
+                                    </ul>
+                                </div>
+                            ) : (
+                                <p className="text-sm text-muted-foreground">
+                                    Data belum tersedia untuk rata-rata keranjang.
+                                </p>
+                            )}
+                        </CardContent>
+                    </Card>
+
+                    <Card>
+                        <CardHeader>
+                            <CardTitle>Persediaan</CardTitle>
+                            <CardDescription>
+                                Produk dengan stok &le; {formatNumber(metrics.lowStockThreshold)} unit
+                            </CardDescription>
+                        </CardHeader>
+                        <CardContent className="space-y-4">
+                            <div className="flex items-baseline justify-between gap-3">
+                                <span className="text-4xl font-semibold">
+                                    {formatNumber(metrics.totals.lowStockCount)}
+                                </span>
+                                <Badge variant="secondary">Batas stok {formatNumber(metrics.lowStockThreshold)}</Badge>
+                            </div>
+                            <p className="text-sm text-muted-foreground">
+                                Pantau dan lakukan pemesanan ulang untuk mencegah kehabisan stok saat permintaan tinggi.
+                            </p>
+                            <p className="text-xs text-muted-foreground">Terakhir diperbarui {lastUpdatedLabel}</p>
+                        </CardContent>
+                    </Card>
+                </section>
             </div>
         </AppLayout>
     );

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\DashboardController;
 use App\Http\Controllers\Master\PermissionController;
 use App\Http\Controllers\Master\ProductController;
 use App\Http\Controllers\Master\RoleController;
@@ -13,9 +14,7 @@ Route::get('/', function () {
 })->name('home');
 
 Route::middleware(['auth', 'verified'])->group(function () {
-    Route::get('dashboard', function () {
-        return Inertia::render('dashboard');
-    })->name('dashboard');
+    Route::get('dashboard', DashboardController::class)->name('dashboard');
 
     Route::prefix('transactions')->name('transactions.')->group(function () {
         Route::get('employee', [TransactionController::class, 'employee'])->name('employee');


### PR DESCRIPTION
## Summary
- add a dedicated DashboardController that caches revenue, transaction, and inventory aggregates
- expose dashboard metrics over Inertia and add scopes/configuration to keep queries efficient
- redesign the dashboard page with summary cards, sales trends, and inventory insights

## Testing
- php artisan test *(fails: missing vendor/autoload.php in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dbaa8ac730832fbd6be392fb53d25c