### PR TITLE
Add inventory reorder thresholds and alerts

### DIFF
--- a/app/Console/Commands/CheckLowStockCommand.php
+++ b/app/Console/Commands/CheckLowStockCommand.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Product;
+use App\Models\User;
+use App\Notifications\LowStockAlert;
+use Illuminate\Console\Command;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Notification;
+
+class CheckLowStockCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'inventory:check-low-stock';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Notify designated users about products below their reorder thresholds';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(): int
+    {
+        $defaultReorderPoint = (int) config('store.inventory.low_stock_threshold', 0);
+
+        $products = Product::query()
+            ->belowReorderPoint($defaultReorderPoint)
+            ->orderBy('stock')
+            ->orderBy('name')
+            ->get();
+
+        if ($products->isEmpty()) {
+            $this->info('No low-stock products detected.');
+
+            return self::SUCCESS;
+        }
+
+        $roles = $this->notificationRoles();
+
+        $usersQuery = User::query();
+
+        if ($roles->isNotEmpty()) {
+            $usersQuery->role($roles->all());
+        }
+
+        $users = $usersQuery->get();
+
+        if ($users->isEmpty()) {
+            $this->warn('Low-stock products found, but no notification recipients are configured.');
+
+            return self::SUCCESS;
+        }
+
+        Notification::send($users, new LowStockAlert($products, $defaultReorderPoint));
+
+        $this->info(sprintf(
+            'Dispatched low-stock alert to %d user(s) for %d product(s).',
+            $users->count(),
+            $products->count()
+        ));
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * @return Collection<int, string>
+     */
+    private function notificationRoles(): Collection
+    {
+        return collect(config('store.inventory.notification_roles', []))
+            ->filter(fn ($role) => is_string($role) && $role !== '')
+            ->values();
+    }
+}

--- a/app/Exports/ProductsExport.php
+++ b/app/Exports/ProductsExport.php
@@ -33,6 +33,8 @@ class ProductsExport implements FromCollection, WithHeadings, WithMapping
             $product->name,
             $product->stock,
             $product->price,
+            $product->reorder_point,
+            $product->reorder_quantity,
             $product->image_path,
             $product->categories
                 ->sortBy('name')
@@ -46,6 +48,16 @@ class ProductsExport implements FromCollection, WithHeadings, WithMapping
      */
     public function headings(): array
     {
-        return ['id', 'barcode', 'name', 'stock', 'price', 'image_path', 'categories'];
+        return [
+            'id',
+            'barcode',
+            'name',
+            'stock',
+            'price',
+            'reorder_point',
+            'reorder_quantity',
+            'image_path',
+            'categories',
+        ];
     }
 }

--- a/app/Http/Requests/Master/StoreProductRequest.php
+++ b/app/Http/Requests/Master/StoreProductRequest.php
@@ -27,9 +27,34 @@ class StoreProductRequest extends FormRequest
             'name' => ['required', 'string', 'max:255'],
             'stock' => ['required', 'integer', 'min:0'],
             'price' => ['required', 'numeric', 'min:0'],
+            'reorder_point' => ['nullable', 'integer', 'min:0'],
+            'reorder_quantity' => ['nullable', 'integer', 'min:0'],
             'image' => ['nullable', 'image', 'max:5120'],
             'category_ids' => ['nullable', 'array'],
             'category_ids.*' => ['integer', Rule::exists('categories', 'id')],
         ];
+    }
+
+    protected function prepareForValidation(): void
+    {
+        $this->merge([
+            'reorder_point' => $this->normalizeNullableInteger('reorder_point'),
+            'reorder_quantity' => $this->normalizeNullableInteger('reorder_quantity'),
+        ]);
+    }
+
+    private function normalizeNullableInteger(string $key): mixed
+    {
+        $value = $this->input($key);
+
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        if (is_numeric($value)) {
+            return (int) $value;
+        }
+
+        return $value;
     }
 }

--- a/app/Http/Requests/Master/UpdateProductRequest.php
+++ b/app/Http/Requests/Master/UpdateProductRequest.php
@@ -36,10 +36,35 @@ class UpdateProductRequest extends FormRequest
             'name' => ['required', 'string', 'max:255'],
             'stock' => ['required', 'integer', 'min:0'],
             'price' => ['required', 'numeric', 'min:0'],
+            'reorder_point' => ['nullable', 'integer', 'min:0'],
+            'reorder_quantity' => ['nullable', 'integer', 'min:0'],
             'image' => ['nullable', 'image', 'max:5120'],
             'remove_image' => ['sometimes', 'boolean'],
             'category_ids' => ['sometimes', 'array'],
             'category_ids.*' => ['integer', Rule::exists('categories', 'id')],
         ];
+    }
+
+    protected function prepareForValidation(): void
+    {
+        $this->merge([
+            'reorder_point' => $this->normalizeNullableInteger('reorder_point'),
+            'reorder_quantity' => $this->normalizeNullableInteger('reorder_quantity'),
+        ]);
+    }
+
+    private function normalizeNullableInteger(string $key): mixed
+    {
+        $value = $this->input($key);
+
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        if (is_numeric($value)) {
+            return (int) $value;
+        }
+
+        return $value;
     }
 }

--- a/app/Imports/ProductsImport.php
+++ b/app/Imports/ProductsImport.php
@@ -35,6 +35,9 @@ class ProductsImport implements ToCollection, WithHeadingRow, SkipsEmptyRows
                 ? (float) $row->get('price')
                 : 0.0;
 
+            $reorderPoint = $this->normalizeNullableInteger($row->get('reorder_point'));
+            $reorderQuantity = $this->normalizeNullableInteger($row->get('reorder_quantity'));
+
             $imagePath = $row->get('image_path');
             $imagePath = is_string($imagePath) && Str::of($imagePath)->trim()->isNotEmpty()
                 ? Str::of($imagePath)->trim()->value()
@@ -46,6 +49,8 @@ class ProductsImport implements ToCollection, WithHeadingRow, SkipsEmptyRows
                     'name' => $name,
                     'stock' => max($stock, 0),
                     'price' => $price >= 0 ? $price : 0,
+                    'reorder_point' => $reorderPoint,
+                    'reorder_quantity' => $reorderQuantity,
                     'image_path' => $imagePath,
                 ],
             );
@@ -86,5 +91,18 @@ class ProductsImport implements ToCollection, WithHeadingRow, SkipsEmptyRows
             })
             ->values()
             ->all();
+    }
+
+    private function normalizeNullableInteger(mixed $value): ?int
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        if (is_numeric($value)) {
+            return max(0, (int) $value);
+        }
+
+        return null;
     }
 }

--- a/app/Notifications/LowStockAlert.php
+++ b/app/Notifications/LowStockAlert.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Models\Product;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
+
+class LowStockAlert extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    /**
+     * @param Collection<int, Product> $products
+     */
+    public function __construct(private readonly Collection $products, private readonly int $defaultReorderPoint)
+    {
+        $this->afterCommit();
+    }
+
+    public function via(object $notifiable): array
+    {
+        $channels = config('store.inventory.notification_channels', ['mail', 'database']);
+
+        return collect($channels)
+            ->filter(fn (string $channel) => in_array($channel, ['mail', 'database'], true))
+            ->unique()
+            ->values()
+            ->all();
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        $productLines = $this->products
+            ->map(function (Product $product): string {
+                $effectivePoint = $product->effectiveReorderPoint($this->defaultReorderPoint);
+                $quantityNote = $product->reorder_quantity ? sprintf(' | reorder qty: %d', $product->reorder_quantity) : '';
+
+                return sprintf(
+                    '%s — stock: %d (reorder at %d%s)',
+                    $product->name,
+                    $product->stock,
+                    $effectivePoint,
+                    $quantityNote
+                );
+            })
+            ->take(10);
+
+        $message = (new MailMessage())
+            ->subject('Low stock alert')
+            ->greeting($this->buildGreeting($notifiable))
+            ->line('The following products have fallen below their reorder thresholds:');
+
+        foreach ($productLines as $line) {
+            $message->line($line);
+        }
+
+        if ($this->products->count() > $productLines->count()) {
+            $message->line(sprintf('...and %d more.', $this->products->count() - $productLines->count()));
+        }
+
+        return $message
+            ->action('Review inventory', url('/master/products'))
+            ->line('Consider replenishing these items soon to avoid stockouts.');
+    }
+
+    public function toArray(object $notifiable): array
+    {
+        return [
+            'title' => 'Low stock alert',
+            'message' => sprintf('%d products are below their reorder thresholds.', $this->products->count()),
+            'default_reorder_point' => $this->defaultReorderPoint,
+            'products' => $this->products
+                ->map(function (Product $product): array {
+                    $effectivePoint = $product->effectiveReorderPoint($this->defaultReorderPoint);
+
+                    return [
+                        'id' => $product->id,
+                        'name' => $product->name,
+                        'stock' => $product->stock,
+                        'reorder_point' => $product->reorder_point,
+                        'effective_reorder_point' => $effectivePoint,
+                        'reorder_quantity' => $product->reorder_quantity,
+                    ];
+                })
+                ->values()
+                ->all(),
+        ];
+    }
+
+    private function buildGreeting(object $notifiable): string
+    {
+        $name = property_exists($notifiable, 'name') ? (string) $notifiable->name : '';
+
+        return Str::of($name)->trim()->isNotEmpty()
+            ? sprintf('Hello %s,', $name)
+            : 'Hello,';
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,13 +1,18 @@
 <?php
 
+use App\Console\Commands\CheckLowStockCommand;
 use App\Http\Middleware\HandleAppearance;
 use App\Http\Middleware\HandleInertiaRequests;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
 use Illuminate\Http\Middleware\AddLinkHeadersForPreloadedAssets;
+use Illuminate\Console\Scheduling\Schedule;
 
 return Application::configure(basePath: dirname(__DIR__))
+    ->withCommands([
+        CheckLowStockCommand::class,
+    ])
     ->withRouting(
         web: __DIR__.'/../routes/web.php',
         commands: __DIR__.'/../routes/console.php',
@@ -21,6 +26,9 @@ return Application::configure(basePath: dirname(__DIR__))
             HandleInertiaRequests::class,
             AddLinkHeadersForPreloadedAssets::class,
         ]);
+    })
+    ->withSchedule(function (Schedule $schedule): void {
+        $schedule->command('inventory:check-low-stock')->dailyAt('08:00');
     })
     ->withExceptions(function (Exceptions $exceptions) {
         //

--- a/config/store.php
+++ b/config/store.php
@@ -8,5 +8,7 @@ return [
     ],
     'inventory' => [
         'low_stock_threshold' => 10,
+        'notification_roles' => ['Administrator'],
+        'notification_channels' => ['mail', 'database'],
     ],
 ];

--- a/database/migrations/2025_10_01_010300_add_reorder_fields_to_products_table.php
+++ b/database/migrations/2025_10_01_010300_add_reorder_fields_to_products_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('products', function (Blueprint $table): void {
+            $table->unsignedInteger('reorder_point')->nullable()->after('stock');
+            $table->unsignedInteger('reorder_quantity')->nullable()->after('reorder_point');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('products', function (Blueprint $table): void {
+            $table->dropColumn(['reorder_point', 'reorder_quantity']);
+        });
+    }
+};

--- a/database/migrations/2025_10_01_010400_create_notifications_table.php
+++ b/database/migrations/2025_10_01_010400_create_notifications_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('notifications', function (Blueprint $table): void {
+            $table->uuid('id')->primary();
+            $table->string('type');
+            $table->morphs('notifiable');
+            $table->text('data');
+            $table->timestamp('read_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('notifications');
+    }
+};

--- a/resources/js/pages/dashboard.tsx
+++ b/resources/js/pages/dashboard.tsx
@@ -31,6 +31,15 @@ interface DashboardMetrics {
     dailySales: DailySalesSnapshot[];
     topSelling: TopSellingItem[];
     lowStockThreshold: number;
+    customReorderCount: number;
+    lowStockProducts: {
+        id: number;
+        name: string;
+        stock: number;
+        reorderPoint: number | null;
+        effectiveReorderPoint: number;
+        reorderQuantity: number | null;
+    }[];
     currency: string;
     lastUpdated: string;
     range: {
@@ -166,7 +175,7 @@ export default function Dashboard({ metrics }: DashboardPageProps) {
                             <div>
                                 <CardTitle className="text-sm font-medium">Produk Hampir Habis</CardTitle>
                                 <CardDescription>
-                                    Stok &le; {formatNumber(metrics.lowStockThreshold)}
+                                    Ambang default &le; {formatNumber(metrics.lowStockThreshold)} unit
                                 </CardDescription>
                             </div>
                             <div className="rounded-full bg-destructive/10 p-2 text-destructive">
@@ -178,6 +187,40 @@ export default function Dashboard({ metrics }: DashboardPageProps) {
                                 {formatNumber(metrics.totals.lowStockCount)}
                             </p>
                             <p className="mt-1 text-xs text-muted-foreground">Periksa persediaan secara berkala</p>
+                            {metrics.customReorderCount > 0 && (
+                                <Badge variant="secondary" className="mt-3 w-fit">
+                                    {formatNumber(metrics.customReorderCount)} ambang khusus
+                                </Badge>
+                            )}
+                            <div className="mt-3 space-y-2">
+                                {metrics.lowStockProducts.length > 0 ? (
+                                    metrics.lowStockProducts.map((product) => (
+                                        <div
+                                            key={product.id}
+                                            className="flex items-center justify-between gap-2 text-xs text-muted-foreground"
+                                        >
+                                            <span className="flex-1 truncate text-foreground">
+                                                {product.name}
+                                            </span>
+                                            <div className="text-right">
+                                                <span className="font-medium text-foreground">
+                                                    {formatNumber(product.stock)} /{' '}
+                                                    {formatNumber(product.effectiveReorderPoint)}
+                                                </span>
+                                                {product.reorderQuantity !== null && (
+                                                    <div className="text-[0.65rem] uppercase tracking-wide">
+                                                        Reorder {formatNumber(product.reorderQuantity)}
+                                                    </div>
+                                                )}
+                                            </div>
+                                        </div>
+                                    ))
+                                ) : (
+                                    <p className="text-xs text-muted-foreground">
+                                        Semua produk berada di atas ambang persediaan.
+                                    </p>
+                                )}
+                            </div>
                         </CardContent>
                     </Card>
                 </section>
@@ -341,7 +384,7 @@ export default function Dashboard({ metrics }: DashboardPageProps) {
                         <CardHeader>
                             <CardTitle>Persediaan</CardTitle>
                             <CardDescription>
-                                Produk dengan stok &le; {formatNumber(metrics.lowStockThreshold)} unit
+                                Produk yang berada di bawah ambang pemesanan ulang
                             </CardDescription>
                         </CardHeader>
                         <CardContent className="space-y-4">
@@ -349,7 +392,16 @@ export default function Dashboard({ metrics }: DashboardPageProps) {
                                 <span className="text-4xl font-semibold">
                                     {formatNumber(metrics.totals.lowStockCount)}
                                 </span>
-                                <Badge variant="secondary">Batas stok {formatNumber(metrics.lowStockThreshold)}</Badge>
+                                <div className="flex flex-wrap items-center gap-2 text-xs">
+                                    <Badge variant="secondary">
+                                        Default {formatNumber(metrics.lowStockThreshold)}
+                                    </Badge>
+                                    {metrics.customReorderCount > 0 && (
+                                        <Badge variant="outline">
+                                            {formatNumber(metrics.customReorderCount)} ambang kustom
+                                        </Badge>
+                                    )}
+                                </div>
                             </div>
                             <p className="text-sm text-muted-foreground">
                                 Pantau dan lakukan pemesanan ulang untuk mencegah kehabisan stok saat permintaan tinggi.


### PR DESCRIPTION
## Summary
- add product reorder point and quantity columns with supporting validation, casting, and import/export updates
- enhance the product management UI and dashboard metrics to surface low-stock indicators and thresholds
- add a scheduled low-stock audit command with configurable notifications for designated users
