### PR TITLE
Add transaction history reporting

### DIFF
--- a/resources/js/pages/transactions/history.tsx
+++ b/resources/js/pages/transactions/history.tsx
@@ -1,0 +1,522 @@
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from '@/components/ui/select';
+import AppLayout from '@/layouts/app-layout';
+import { Head, Link, useForm } from '@inertiajs/react';
+import { FormEvent, useMemo } from 'react';
+
+interface CashierOption {
+    id: number;
+    name: string;
+}
+
+interface TransactionRow {
+    id: number;
+    number: string;
+    created_at: string | null;
+    subtotal: number;
+    tax_total: number;
+    total: number;
+    items_count: number;
+    cashier: { id: number; name: string } | null;
+    detail_url: string;
+}
+
+interface PaginationLink {
+    url: string | null;
+    label: string;
+    active: boolean;
+}
+
+interface PaginatedResponse<T> {
+    data: T[];
+    links: PaginationLink[];
+    from: number | null;
+    to: number | null;
+    total: number;
+}
+
+interface HistoryFilters {
+    start_date: string | null;
+    end_date: string | null;
+    cashier_id: number | null;
+    min_total: number | null;
+    max_total: number | null;
+}
+
+interface HistorySummary {
+    transactions: number;
+    subtotal: number;
+    tax_total: number;
+    total: number;
+    items: number;
+}
+
+interface DailyBreakdownPoint {
+    date: string;
+    revenue: number;
+    transactions: number;
+    items: number;
+}
+
+interface TransactionHistoryPageProps {
+    filters: HistoryFilters;
+    transactions: PaginatedResponse<TransactionRow>;
+    summary: HistorySummary;
+    daily: DailyBreakdownPoint[];
+    cashiers: CashierOption[];
+    historyUrl: string;
+    employeeUrl: string;
+}
+
+const formatCurrency = (value: number) =>
+    new Intl.NumberFormat('id-ID', {
+        style: 'currency',
+        currency: 'IDR',
+        minimumFractionDigits: 2,
+    }).format(value);
+
+const formatDateTime = (value: string | null) => {
+    if (!value) {
+        return '—';
+    }
+
+    return new Intl.DateTimeFormat('id-ID', {
+        dateStyle: 'medium',
+        timeStyle: 'short',
+    }).format(new Date(value));
+};
+
+export default function TransactionHistory({
+    filters,
+    transactions,
+    summary,
+    daily,
+    cashiers,
+    historyUrl,
+    employeeUrl,
+}: TransactionHistoryPageProps) {
+    const form = useForm({
+        start_date: filters.start_date ?? '',
+        end_date: filters.end_date ?? '',
+        cashier_id: filters.cashier_id ? String(filters.cashier_id) : '',
+        min_total: filters.min_total != null ? String(filters.min_total) : '',
+        max_total: filters.max_total != null ? String(filters.max_total) : '',
+    });
+
+    const appliedFilters = useMemo(
+        () =>
+            [
+                form.data.start_date && {
+                    label: 'Mulai',
+                    value: form.data.start_date,
+                },
+                form.data.end_date && {
+                    label: 'Selesai',
+                    value: form.data.end_date,
+                },
+                form.data.cashier_id && {
+                    label: 'Kasir',
+                    value:
+                        cashiers.find((cashier) =>
+                            cashier.id === Number(form.data.cashier_id),
+                        )?.name ?? 'Tidak diketahui',
+                },
+                form.data.min_total && {
+                    label: 'Total minimum',
+                    value: formatCurrency(Number(form.data.min_total)),
+                },
+                form.data.max_total && {
+                    label: 'Total maksimum',
+                    value: formatCurrency(Number(form.data.max_total)),
+                },
+            ].filter(Boolean) as { label: string; value: string }[],
+        [
+            cashiers,
+            form.data.cashier_id,
+            form.data.end_date,
+            form.data.max_total,
+            form.data.min_total,
+            form.data.start_date,
+        ],
+    );
+
+    const handleSubmit = (event: FormEvent) => {
+        event.preventDefault();
+        form.get(historyUrl, {
+            replace: true,
+            preserveScroll: true,
+        });
+    };
+
+    const handleReset = () => {
+        form.setData({
+            start_date: '',
+            end_date: '',
+            cashier_id: '',
+            min_total: '',
+            max_total: '',
+        });
+
+        form.get(historyUrl, {
+            replace: true,
+            preserveScroll: true,
+        });
+    };
+
+    return (
+        <AppLayout
+            breadcrumbs={[
+                { title: 'Transaksi', href: employeeUrl },
+                { title: 'Riwayat', href: historyUrl },
+            ]}
+        >
+            <Head title="Riwayat Transaksi" />
+
+            <div className="space-y-6">
+                <header className="space-y-2">
+                    <h1 className="text-3xl font-semibold tracking-tight">
+                        Riwayat transaksi
+                    </h1>
+                    <p className="text-muted-foreground">
+                        Tinjau transaksi sebelumnya, filter berdasarkan kasir atau
+                        rentang tanggal, dan analisa performa penjualan toko.
+                    </p>
+                </header>
+
+                <div className="grid gap-6 lg:grid-cols-[2fr,1fr]">
+                    <Card>
+                        <CardHeader>
+                            <CardTitle>Filter</CardTitle>
+                            <CardDescription>
+                                Pilih kriteria untuk mempersempit daftar transaksi.
+                            </CardDescription>
+                        </CardHeader>
+                        <CardContent>
+                            <form className="grid gap-4 sm:grid-cols-2" onSubmit={handleSubmit}>
+                                <div className="space-y-2">
+                                    <Label htmlFor="start_date">Tanggal mulai</Label>
+                                    <Input
+                                        id="start_date"
+                                        type="date"
+                                        value={form.data.start_date}
+                                        onChange={(event) =>
+                                            form.setData('start_date', event.target.value)
+                                        }
+                                    />
+                                </div>
+                                <div className="space-y-2">
+                                    <Label htmlFor="end_date">Tanggal selesai</Label>
+                                    <Input
+                                        id="end_date"
+                                        type="date"
+                                        value={form.data.end_date}
+                                        onChange={(event) =>
+                                            form.setData('end_date', event.target.value)
+                                        }
+                                    />
+                                </div>
+                                <div className="space-y-2">
+                                    <Label>Kasir</Label>
+                                    <Select
+                                        value={form.data.cashier_id}
+                                        onValueChange={(value) =>
+                                            form.setData('cashier_id', value)
+                                        }
+                                    >
+                                        <SelectTrigger>
+                                            <SelectValue placeholder="Semua kasir" />
+                                        </SelectTrigger>
+                                        <SelectContent>
+                                            <SelectItem value="">Semua kasir</SelectItem>
+                                            {cashiers.map((cashier) => (
+                                                <SelectItem
+                                                    key={cashier.id}
+                                                    value={String(cashier.id)}
+                                                >
+                                                    {cashier.name}
+                                                </SelectItem>
+                                            ))}
+                                        </SelectContent>
+                                    </Select>
+                                </div>
+                                <div className="space-y-2">
+                                    <Label htmlFor="min_total">Total minimum</Label>
+                                    <Input
+                                        id="min_total"
+                                        type="number"
+                                        min="0"
+                                        step="0.01"
+                                        placeholder="0"
+                                        value={form.data.min_total}
+                                        onChange={(event) =>
+                                            form.setData('min_total', event.target.value)
+                                        }
+                                    />
+                                </div>
+                                <div className="space-y-2">
+                                    <Label htmlFor="max_total">Total maksimum</Label>
+                                    <Input
+                                        id="max_total"
+                                        type="number"
+                                        min="0"
+                                        step="0.01"
+                                        placeholder="0"
+                                        value={form.data.max_total}
+                                        onChange={(event) =>
+                                            form.setData('max_total', event.target.value)
+                                        }
+                                    />
+                                </div>
+                                <div className="flex items-end gap-2">
+                                    <Button type="submit" disabled={form.processing}>
+                                        Terapkan
+                                    </Button>
+                                    <Button
+                                        type="button"
+                                        variant="outline"
+                                        onClick={handleReset}
+                                        disabled={form.processing}
+                                    >
+                                        Setel ulang
+                                    </Button>
+                                </div>
+                            </form>
+
+                            {appliedFilters.length > 0 && (
+                                <div className="mt-6 space-y-2">
+                                    <h3 className="text-sm font-medium text-muted-foreground">
+                                        Filter aktif
+                                    </h3>
+                                    <ul className="flex flex-wrap gap-2 text-sm">
+                                        {appliedFilters.map((filter) => (
+                                            <li
+                                                key={`${filter.label}-${filter.value}`}
+                                                className="rounded-full border border-border px-3 py-1"
+                                            >
+                                                <span className="font-medium text-foreground">
+                                                    {filter.label}:
+                                                </span>{' '}
+                                                {filter.value}
+                                            </li>
+                                        ))}
+                                    </ul>
+                                </div>
+                            )}
+                        </CardContent>
+                    </Card>
+
+                    <Card className="h-full">
+                        <CardHeader>
+                            <CardTitle>Ringkasan</CardTitle>
+                            <CardDescription>
+                                Angka agregat berdasarkan filter yang diterapkan.
+                            </CardDescription>
+                        </CardHeader>
+                        <CardContent>
+                            <dl className="grid gap-4">
+                                <div className="rounded-lg border border-border p-4">
+                                    <dt className="text-sm text-muted-foreground">
+                                        Total transaksi
+                                    </dt>
+                                    <dd className="text-2xl font-semibold text-foreground">
+                                        {summary.transactions.toLocaleString('id-ID')}
+                                    </dd>
+                                </div>
+                                <div className="rounded-lg border border-border p-4">
+                                    <dt className="text-sm text-muted-foreground">
+                                        Barang terjual
+                                    </dt>
+                                    <dd className="text-2xl font-semibold text-foreground">
+                                        {summary.items.toLocaleString('id-ID')}
+                                    </dd>
+                                </div>
+                                <div className="rounded-lg border border-border p-4">
+                                    <dt className="text-sm text-muted-foreground">
+                                        Subtotal
+                                    </dt>
+                                    <dd className="text-xl font-semibold text-foreground">
+                                        {formatCurrency(summary.subtotal)}
+                                    </dd>
+                                </div>
+                                <div className="rounded-lg border border-border p-4">
+                                    <dt className="text-sm text-muted-foreground">
+                                        Pajak
+                                    </dt>
+                                    <dd className="text-xl font-semibold text-foreground">
+                                        {formatCurrency(summary.tax_total)}
+                                    </dd>
+                                </div>
+                                <div className="rounded-lg border border-border p-4">
+                                    <dt className="text-sm text-muted-foreground">
+                                        Total penjualan
+                                    </dt>
+                                    <dd className="text-xl font-semibold text-foreground">
+                                        {formatCurrency(summary.total)}
+                                    </dd>
+                                </div>
+                            </dl>
+                        </CardContent>
+                    </Card>
+                </div>
+
+                <Card>
+                    <CardHeader>
+                        <CardTitle>Daftar transaksi</CardTitle>
+                        <CardDescription>
+                            Menampilkan transaksi terbaru terlebih dahulu sesuai filter.
+                        </CardDescription>
+                    </CardHeader>
+                    <CardContent className="space-y-4">
+                        <div className="overflow-x-auto">
+                            <table className="min-w-full divide-y divide-border text-left text-sm">
+                                <thead className="bg-muted/60 text-xs uppercase tracking-wider text-muted-foreground">
+                                    <tr>
+                                        <th className="px-4 py-3 font-medium">Nomor</th>
+                                        <th className="px-4 py-3 font-medium">Waktu</th>
+                                        <th className="px-4 py-3 font-medium text-right">Barang</th>
+                                        <th className="px-4 py-3 font-medium text-right">Subtotal</th>
+                                        <th className="px-4 py-3 font-medium text-right">Pajak</th>
+                                        <th className="px-4 py-3 font-medium text-right">Total</th>
+                                        <th className="px-4 py-3 font-medium">Kasir</th>
+                                        <th className="px-4 py-3 font-medium text-right">Aksi</th>
+                                    </tr>
+                                </thead>
+                                <tbody className="divide-y divide-border">
+                                    {transactions.data.length > 0 ? (
+                                        transactions.data.map((transaction) => (
+                                            <tr key={transaction.id} className="hover:bg-muted/30">
+                                                <td className="px-4 py-3 font-medium">
+                                                    {transaction.number}
+                                                </td>
+                                                <td className="px-4 py-3">
+                                                    {formatDateTime(transaction.created_at)}
+                                                </td>
+                                                <td className="px-4 py-3 text-right">
+                                                    {transaction.items_count.toLocaleString('id-ID')}
+                                                </td>
+                                                <td className="px-4 py-3 text-right">
+                                                    {formatCurrency(transaction.subtotal)}
+                                                </td>
+                                                <td className="px-4 py-3 text-right">
+                                                    {formatCurrency(transaction.tax_total)}
+                                                </td>
+                                                <td className="px-4 py-3 text-right">
+                                                    {formatCurrency(transaction.total)}
+                                                </td>
+                                                <td className="px-4 py-3">
+                                                    {transaction.cashier?.name ?? '—'}
+                                                </td>
+                                                <td className="px-4 py-3 text-right">
+                                                    <Button asChild variant="outline" size="sm">
+                                                        <Link href={transaction.detail_url}>
+                                                            Detail
+                                                        </Link>
+                                                    </Button>
+                                                </td>
+                                            </tr>
+                                        ))
+                                    ) : (
+                                        <tr>
+                                            <td
+                                                colSpan={8}
+                                                className="px-4 py-6 text-center text-muted-foreground"
+                                            >
+                                                Tidak ada transaksi yang cocok dengan filter saat ini.
+                                            </td>
+                                        </tr>
+                                    )}
+                                </tbody>
+                            </table>
+                        </div>
+
+                        <div className="flex flex-wrap items-center justify-between gap-4 text-sm text-muted-foreground">
+                            <div>
+                                Menampilkan {transactions.from ?? 0} - {transactions.to ?? 0} dari{' '}
+                                {transactions.total.toLocaleString('id-ID')} transaksi
+                            </div>
+                            <nav className="flex flex-wrap items-center gap-2">
+                                {transactions.links.map((link, index) => {
+                                    const classes = `rounded-md border px-3 py-1 text-sm transition-colors ${
+                                        link.active
+                                            ? 'border-primary bg-primary text-primary-foreground'
+                                            : 'border-border bg-background text-foreground hover:bg-muted'
+                                    }`;
+
+                                    if (link.url === null) {
+                                        return (
+                                            <span
+                                                // eslint-disable-next-line react/no-array-index-key
+                                                key={`${link.label}-${index}`}
+                                                className={`${classes} pointer-events-none opacity-50`}
+                                                dangerouslySetInnerHTML={{ __html: link.label }}
+                                            />
+                                        );
+                                    }
+
+                                    return (
+                                        <Link
+                                            // eslint-disable-next-line react/no-array-index-key
+                                            key={`${link.label}-${index}`}
+                                            href={link.url}
+                                            className={classes}
+                                            dangerouslySetInnerHTML={{ __html: link.label }}
+                                        />
+                                    );
+                                })}
+                            </nav>
+                        </div>
+                    </CardContent>
+                </Card>
+
+                <Card>
+                    <CardHeader>
+                        <CardTitle>Ringkasan harian</CardTitle>
+                        <CardDescription>
+                            Total penjualan per hari sebagai referensi cepat tanpa grafik.
+                        </CardDescription>
+                    </CardHeader>
+                    <CardContent>
+                        {daily.length > 0 ? (
+                            <ul className="divide-y divide-border text-sm">
+                                {daily.map((entry) => (
+                                    <li
+                                        key={entry.date}
+                                        className="flex flex-wrap items-center justify-between gap-3 py-3"
+                                    >
+                                        <div>
+                                            <p className="font-medium text-foreground">
+                                                {new Intl.DateTimeFormat('id-ID', {
+                                                    dateStyle: 'medium',
+                                                }).format(new Date(entry.date))}
+                                            </p>
+                                            <p className="text-xs text-muted-foreground">
+                                                {entry.transactions.toLocaleString('id-ID')} transaksi ·{' '}
+                                                {entry.items.toLocaleString('id-ID')} item
+                                            </p>
+                                        </div>
+                                        <div className="text-base font-semibold text-foreground">
+                                            {formatCurrency(entry.revenue)}
+                                        </div>
+                                    </li>
+                                ))}
+                            </ul>
+                        ) : (
+                            <p className="text-sm text-muted-foreground">
+                                Tidak ada data harian untuk rentang tanggal yang dipilih.
+                            </p>
+                        )}
+                    </CardContent>
+                </Card>
+            </div>
+        </AppLayout>
+    );
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -22,6 +22,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
         Route::get('products/{product:barcode}', [TransactionController::class, 'showProduct'])->name('products.show');
         Route::get('customer/latest', [TransactionController::class, 'latest'])->name('customer.latest');
         Route::get('customer/{transaction}', [TransactionController::class, 'customer'])->name('customer');
+        Route::get('history', [TransactionController::class, 'history'])->name('history');
     });
 
     Route::prefix('master')->name('master.')->group(function () {

--- a/tests/Feature/Transactions/TransactionHistoryTest.php
+++ b/tests/Feature/Transactions/TransactionHistoryTest.php
@@ -1,0 +1,144 @@
+<?php
+
+use App\Models\Transaction;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Str;
+use Inertia\Testing\AssertableInertia as Assert;
+
+uses(RefreshDatabase::class);
+
+function createTransactionRecord(?User $cashier, Carbon $createdAt, float $subtotal, float $taxTotal, float $total, int $items): Transaction
+{
+    $transaction = Transaction::query()->create([
+        'number' => sprintf('TRX-%s', Str::upper(Str::random(8))),
+        'user_id' => $cashier?->id,
+        'items_count' => $items,
+        'ppn_rate' => 11.0,
+        'subtotal' => $subtotal,
+        'tax_total' => $taxTotal,
+        'total' => $total,
+    ]);
+
+    Transaction::withoutTimestamps(function () use ($transaction, $createdAt): void {
+        $transaction->forceFill([
+            'created_at' => $createdAt,
+            'updated_at' => $createdAt,
+        ])->save();
+    });
+
+    return $transaction->fresh();
+}
+
+beforeEach(function (): void {
+    $this->withoutVite();
+});
+
+test('guests cannot access transaction history', function () {
+    $this->get(route('transactions.history'))->assertRedirect(route('login'));
+});
+
+test('authorized users can view transaction history overview', function () {
+    $user = User::factory()->create();
+    $cashierA = User::factory()->create(['name' => 'Kasir A']);
+    $cashierB = User::factory()->create(['name' => 'Kasir B']);
+
+    $first = createTransactionRecord(
+        $cashierA,
+        Carbon::now()->subDay(),
+        subtotal: 150.0,
+        taxTotal: 15.0,
+        total: 165.0,
+        items: 4,
+    );
+
+    $second = createTransactionRecord(
+        $cashierB,
+        Carbon::now(),
+        subtotal: 200.0,
+        taxTotal: 20.0,
+        total: 220.0,
+        items: 6,
+    );
+
+    $this->actingAs($user)
+        ->get(route('transactions.history'))
+        ->assertOk()
+        ->assertInertia(fn (Assert $page) => $page
+            ->component('transactions/history')
+            ->where('filters.start_date', null)
+            ->has('transactions.data', 2)
+            ->where('transactions.data', function ($items) use ($first, $second) {
+                $ids = collect($items)->pluck('id')->sort()->values()->all();
+
+                return $ids === collect([$first->id, $second->id])->sort()->values()->all();
+            })
+            ->where('summary.transactions', 2)
+            ->where('summary.total', 385)
+            ->has('cashiers', 3) // includes the acting user in the selectable cashiers
+        );
+});
+
+test('filters restrict the transaction history results', function () {
+    $viewer = User::factory()->create();
+    $cashier = User::factory()->create(['name' => 'Cashier Filtered']);
+    $otherCashier = User::factory()->create();
+
+    createTransactionRecord(
+        $cashier,
+        Carbon::parse('2024-01-05 10:00:00'),
+        subtotal: 120.0,
+        taxTotal: 12.0,
+        total: 132.0,
+        items: 3,
+    );
+
+    $matching = createTransactionRecord(
+        $cashier,
+        Carbon::parse('2024-01-15 09:30:00'),
+        subtotal: 180.0,
+        taxTotal: 18.0,
+        total: 198.0,
+        items: 5,
+    );
+
+    createTransactionRecord(
+        $otherCashier,
+        Carbon::parse('2024-02-01 08:00:00'),
+        subtotal: 250.0,
+        taxTotal: 25.0,
+        total: 275.0,
+        items: 7,
+    );
+
+    $this->actingAs($viewer)
+        ->get(route('transactions.history', [
+            'start_date' => '2024-01-10',
+            'end_date' => '2024-01-20',
+            'cashier_id' => $cashier->id,
+            'min_total' => 150,
+            'max_total' => 220,
+        ]))
+        ->assertOk()
+        ->assertInertia(fn (Assert $page) => $page
+            ->component('transactions/history')
+            ->where('filters.start_date', '2024-01-10')
+            ->where('filters.end_date', '2024-01-20')
+            ->where('filters.cashier_id', $cashier->id)
+            ->where('filters.min_total', 150)
+            ->where('filters.max_total', 220)
+            ->has('transactions.data', 1, fn (Assert $item) => $item
+                ->where('id', $matching->id)
+                ->where('total', fn ($value) => (float) $value === 198.0)
+                ->etc()
+            )
+            ->where('summary.transactions', 1)
+            ->where('summary.total', fn ($value) => (float) $value === 198.0)
+            ->has('daily', 1, fn (Assert $day) => $day
+                ->where('revenue', fn ($value) => (float) $value === 198.0)
+                ->where('transactions', 1)
+                ->etc()
+            )
+        );
+});


### PR DESCRIPTION
## Summary
- add an authenticated `/transactions/history` endpoint that serves paginated transactions, aggregates, and filter metadata
- build an Inertia-powered transaction history view with filtering controls, summaries, and navigation links
- cover history access and filtering behaviours with new feature tests

## Testing
- php artisan test --testsuite=Feature --filter=TransactionHistory

------
https://chatgpt.com/codex/tasks/task_e_68dca328470c832f971ab755d63cc9b4