### PR TITLE
Add discount and payment capture to transactions

### DIFF
--- a/app/Http/Requests/Transactions/StoreTransactionRequest.php
+++ b/app/Http/Requests/Transactions/StoreTransactionRequest.php
@@ -3,15 +3,42 @@
 namespace App\Http\Requests\Transactions;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\Validator;
 
 class StoreTransactionRequest extends FormRequest
 {
+    /**
+     * Supported payment methods for a transaction.
+     *
+     * @var list<string>
+     */
+    public const PAYMENT_METHODS = [
+        'cash',
+        'card',
+        'bank_transfer',
+        'e_wallet',
+        'other',
+    ];
+
     /**
      * Determine if the user is authorized to make this request.
      */
     public function authorize(): bool
     {
         return $this->user() !== null;
+    }
+
+    /**
+     * Prepare the data for validation.
+     */
+    protected function prepareForValidation(): void
+    {
+        $this->merge([
+            'discount_type' => $this->filled('discount_type') ? $this->input('discount_type') : null,
+            'discount_value' => $this->filled('discount_value') ? $this->input('discount_value') : null,
+            'notes' => $this->filled('notes') ? $this->input('notes') : null,
+        ]);
     }
 
     /**
@@ -25,6 +52,38 @@ class StoreTransactionRequest extends FormRequest
             'items' => ['required', 'array', 'min:1'],
             'items.*.product_id' => ['required', 'integer', 'exists:products,id'],
             'items.*.quantity' => ['required', 'integer', 'min:1'],
+            'discount_type' => ['nullable', 'string', Rule::in(['percentage', 'value'])],
+            'discount_value' => ['nullable', 'numeric', 'min:0'],
+            'payment_method' => ['required', 'string', Rule::in(self::PAYMENT_METHODS)],
+            'amount_paid' => ['required', 'numeric', 'min:0'],
+            'notes' => ['nullable', 'string', 'max:1000'],
         ];
+    }
+
+    /**
+     * Configure the validator instance.
+     */
+    public function withValidator(Validator $validator): void
+    {
+        $validator->after(function (Validator $validator): void {
+            if ($validator->errors()->isNotEmpty()) {
+                return;
+            }
+
+            $discountType = $this->input('discount_type');
+            $rawDiscountValue = $this->input('discount_value');
+
+            if ($discountType === null && $rawDiscountValue !== null && $rawDiscountValue !== '') {
+                $validator->errors()->add('discount_type', 'Select a discount type when providing a discount value.');
+            }
+
+            if ($discountType !== null && ($rawDiscountValue === null || $rawDiscountValue === '')) {
+                $validator->errors()->add('discount_value', 'Provide a value for the selected discount type.');
+            }
+
+            if ($discountType === 'percentage' && is_numeric($rawDiscountValue) && (float) $rawDiscountValue > 100) {
+                $validator->errors()->add('discount_value', 'Percentage discounts cannot exceed 100%.');
+            }
+        });
     }
 }

--- a/app/Models/Transaction.php
+++ b/app/Models/Transaction.php
@@ -23,7 +23,12 @@ class Transaction extends Model
         'ppn_rate',
         'subtotal',
         'tax_total',
+        'discount_total',
         'total',
+        'payment_method',
+        'amount_paid',
+        'change_due',
+        'notes',
     ];
 
     /**
@@ -33,7 +38,10 @@ class Transaction extends Model
         'ppn_rate' => 'decimal:2',
         'subtotal' => 'decimal:2',
         'tax_total' => 'decimal:2',
+        'discount_total' => 'decimal:2',
         'total' => 'decimal:2',
+        'amount_paid' => 'decimal:2',
+        'change_due' => 'decimal:2',
     ];
 
     public function items(): HasMany

--- a/database/migrations/2025_10_01_000100_create_transactions_table.php
+++ b/database/migrations/2025_10_01_000100_create_transactions_table.php
@@ -19,7 +19,12 @@ return new class extends Migration
             $table->decimal('ppn_rate', 5, 2);
             $table->decimal('subtotal', 12, 2);
             $table->decimal('tax_total', 12, 2);
+            $table->decimal('discount_total', 12, 2)->default(0);
             $table->decimal('total', 12, 2);
+            $table->string('payment_method', 50);
+            $table->decimal('amount_paid', 12, 2);
+            $table->decimal('change_due', 12, 2);
+            $table->text('notes')->nullable();
             $table->timestamps();
         });
     }

--- a/tests/Feature/Transactions/TransactionHistoryTest.php
+++ b/tests/Feature/Transactions/TransactionHistoryTest.php
@@ -18,7 +18,12 @@ function createTransactionRecord(?User $cashier, Carbon $createdAt, float $subto
         'ppn_rate' => 11.0,
         'subtotal' => $subtotal,
         'tax_total' => $taxTotal,
+        'discount_total' => 0,
         'total' => $total,
+        'payment_method' => 'cash',
+        'amount_paid' => $total,
+        'change_due' => 0,
+        'notes' => null,
     ]);
 
     Transaction::withoutTimestamps(function () use ($transaction, $createdAt): void {

--- a/tests/Feature/Transactions/TransactionStoreTest.php
+++ b/tests/Feature/Transactions/TransactionStoreTest.php
@@ -1,0 +1,143 @@
+<?php
+
+use App\Models\Product;
+use App\Models\Transaction;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function (): void {
+    $this->withoutVite();
+});
+
+function createProduct(array $attributes = []): Product
+{
+    return Product::query()->create(array_merge([
+        'barcode' => 'PRD-' . Str::upper(Str::random(8)),
+        'name' => 'Test Product',
+        'stock' => 50,
+        'price' => 100.0,
+    ], $attributes));
+}
+
+test('employee can store a transaction with a percentage discount', function () {
+    $user = User::factory()->create();
+    $product = createProduct(['stock' => 10, 'price' => 100]);
+
+    $response = $this->actingAs($user)->post(route('transactions.store'), [
+        'items' => [
+            ['product_id' => $product->id, 'quantity' => 2],
+        ],
+        'discount_type' => 'percentage',
+        'discount_value' => 10,
+        'payment_method' => 'cash',
+        'amount_paid' => 200,
+        'notes' => 'Customer birthday discount',
+    ]);
+
+    $response->assertRedirect(route('transactions.employee'));
+
+    $transaction = Transaction::query()->with('items')->latest()->first();
+    expect($transaction)->not->toBeNull();
+
+    expect((float) $transaction->subtotal)->toBe(200.0)
+        ->and((float) $transaction->tax_total)->toBe(22.0)
+        ->and((float) $transaction->discount_total)->toBe(22.2)
+        ->and((float) $transaction->total)->toBe(199.8)
+        ->and($transaction->payment_method)->toBe('cash')
+        ->and((float) $transaction->amount_paid)->toBe(200.0)
+        ->and((float) $transaction->change_due)->toBe(0.2)
+        ->and($transaction->notes)->toBe('Customer birthday discount');
+
+    expect($transaction->items)->toHaveCount(1);
+    expect($transaction->items->first()->quantity)->toBe(2);
+    expect($product->fresh()->stock)->toBe(8);
+});
+
+test('fixed discounts are capped at the transaction total and change is recorded', function () {
+    $user = User::factory()->create();
+    $product = createProduct(['stock' => 5, 'price' => 50]);
+
+    $response = $this->actingAs($user)->post(route('transactions.store'), [
+        'items' => [
+            ['product_id' => $product->id, 'quantity' => 1],
+        ],
+        'discount_type' => 'value',
+        'discount_value' => 100,
+        'payment_method' => 'card',
+        'amount_paid' => 0,
+    ]);
+
+    $response->assertRedirect(route('transactions.employee'));
+
+    $transaction = Transaction::query()->latest()->first();
+    expect($transaction)->not->toBeNull();
+
+    $grossTotal = 50 + 5.5; // subtotal + tax at 11%
+
+    expect((float) $transaction->discount_total)->toBe(round($grossTotal, 2))
+        ->and((float) $transaction->total)->toBe(0.0)
+        ->and((float) $transaction->amount_paid)->toBe(0.0)
+        ->and((float) $transaction->change_due)->toBe(0.0)
+        ->and($transaction->payment_method)->toBe('card');
+});
+
+test('amount paid must cover the total due', function () {
+    $user = User::factory()->create();
+    $product = createProduct(['stock' => 3, 'price' => 75]);
+
+    $response = $this->actingAs($user)->from(route('transactions.employee'))->post(route('transactions.store'), [
+        'items' => [
+            ['product_id' => $product->id, 'quantity' => 1],
+        ],
+        'payment_method' => 'cash',
+        'amount_paid' => 20,
+    ]);
+
+    $response->assertRedirect(route('transactions.employee'))
+        ->assertSessionHasErrors(['amount_paid']);
+
+    expect(Transaction::count())->toBe(0);
+    expect($product->fresh()->stock)->toBe(3);
+});
+
+test('discount values require a matching type', function () {
+    $user = User::factory()->create();
+    $product = createProduct(['stock' => 4, 'price' => 60]);
+
+    $response = $this->actingAs($user)->from(route('transactions.employee'))->post(route('transactions.store'), [
+        'items' => [
+            ['product_id' => $product->id, 'quantity' => 1],
+        ],
+        'discount_value' => 10,
+        'payment_method' => 'other',
+        'amount_paid' => 100,
+    ]);
+
+    $response->assertRedirect(route('transactions.employee'))
+        ->assertSessionHasErrors(['discount_type']);
+
+    expect(Transaction::count())->toBe(0);
+});
+
+test('percentage discounts cannot exceed 100 percent', function () {
+    $user = User::factory()->create();
+    $product = createProduct(['stock' => 6, 'price' => 80]);
+
+    $response = $this->actingAs($user)->from(route('transactions.employee'))->post(route('transactions.store'), [
+        'items' => [
+            ['product_id' => $product->id, 'quantity' => 1],
+        ],
+        'discount_type' => 'percentage',
+        'discount_value' => 150,
+        'payment_method' => 'cash',
+        'amount_paid' => 500,
+    ]);
+
+    $response->assertRedirect(route('transactions.employee'))
+        ->assertSessionHasErrors(['discount_value']);
+
+    expect(Transaction::count())->toBe(0);
+});


### PR DESCRIPTION
## Summary
- extend the transaction request rules to validate discount options, tender information, and optional notes
- calculate and persist discount totals, payment details, and change in the controller, model, and schema
- enhance the employee POS UI to handle discounts, payments, and change due while adding focused feature coverage

## Testing
- `php artisan test --filter=TransactionStoreTest`


------
https://chatgpt.com/codex/tasks/task_e_68dcab1c3480832fb2ec9b7ef3c22115