### PR TITLE
Enable automatic receipt printing after completing transactions

### DIFF
--- a/resources/js/pages/transactions/customer.tsx
+++ b/resources/js/pages/transactions/customer.tsx
@@ -2,7 +2,7 @@ import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import CustomerLayout from '@/layouts/customer-layout';
 import { Head, router } from '@inertiajs/react';
-import { useEffect } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { RefreshCcw } from 'lucide-react';
 
 interface TransactionItemSummary {
@@ -53,6 +53,39 @@ const formatDate = (value: string | null) => {
 };
 
 export default function CustomerDisplay({ transaction, autoRefresh, latestUrl }: CustomerDisplayProps) {
+    const [shouldAutoPrint, setShouldAutoPrint] = useState(false);
+    const hasPrintedRef = useRef(false);
+
+    useEffect(() => {
+        if (typeof window === 'undefined') {
+            return;
+        }
+
+        const params = new URLSearchParams(window.location.search);
+        if (params.get('print') === '1') {
+            setShouldAutoPrint(true);
+        }
+    }, []);
+
+    useEffect(() => {
+        if (typeof window === 'undefined') {
+            return;
+        }
+
+        if (!shouldAutoPrint || !transaction || hasPrintedRef.current) {
+            return;
+        }
+
+        hasPrintedRef.current = true;
+        window.print();
+
+        if (window.history && window.history.replaceState) {
+            const url = new URL(window.location.href);
+            url.searchParams.delete('print');
+            window.history.replaceState({}, document.title, url.toString());
+        }
+    }, [shouldAutoPrint, transaction]);
+
     useEffect(() => {
         if (!autoRefresh) {
             return;

--- a/resources/js/pages/transactions/history.tsx
+++ b/resources/js/pages/transactions/history.tsx
@@ -454,7 +454,6 @@ export default function TransactionHistory({
                                     if (link.url === null) {
                                         return (
                                             <span
-                                                // eslint-disable-next-line react/no-array-index-key
                                                 key={`${link.label}-${index}`}
                                                 className={`${classes} pointer-events-none opacity-50`}
                                                 dangerouslySetInnerHTML={{ __html: link.label }}
@@ -464,7 +463,6 @@ export default function TransactionHistory({
 
                                     return (
                                         <Link
-                                            // eslint-disable-next-line react/no-array-index-key
                                             key={`${link.label}-${index}`}
                                             href={link.url}
                                             className={classes}


### PR DESCRIPTION
## Summary
- automatically open the most recent receipt in a new tab with print instructions after a sale is completed from the employee POS
- trigger printing automatically on the customer receipt view when opened with the print query parameter and clear it afterwards
- tidy the transaction history pagination markup by removing now-unnecessary ESLint suppression comments
