### PR TITLE
Filter sidebar menu items by user permissions

### DIFF
--- a/resources/js/components/app-sidebar.tsx
+++ b/resources/js/components/app-sidebar.tsx
@@ -38,16 +38,19 @@ const mainNavItems: NavItem[] = [
         title: 'Roles',
         href: '/master/roles',
         icon: Shield,
+        permissions: ['manage roles'],
     },
     {
         title: 'Users',
         href: '/master/users',
         icon: Users,
+        permissions: ['manage users'],
     },
     {
         title: 'Permissions',
         href: '/master/permissions',
         icon: KeyRound,
+        permissions: ['manage permissions'],
     },
     {
         title: 'Products',

--- a/resources/js/components/nav-main.tsx
+++ b/resources/js/components/nav-main.tsx
@@ -5,16 +5,35 @@ import {
     SidebarMenuButton,
     SidebarMenuItem,
 } from '@/components/ui/sidebar';
-import { type NavItem } from '@/types';
+import { type NavItem, type SharedData } from '@/types';
 import { Link, usePage } from '@inertiajs/react';
 
 export function NavMain({ items = [] }: { items: NavItem[] }) {
-    const page = usePage();
+    const page = usePage<SharedData>();
+    const userPermissions = new Set(page.props.auth.user?.permissions ?? []);
+    const userRoles = new Set(page.props.auth.user?.roles ?? []);
+
+    const visibleItems = items.filter((item) => {
+        const requiredPermissions = item.permissions ?? [];
+        const requiredRoles = item.roles ?? [];
+
+        const hasPermissions =
+            requiredPermissions.length === 0 ||
+            requiredPermissions.every((permission) =>
+                userPermissions.has(permission),
+            );
+
+        const hasRoles =
+            requiredRoles.length === 0 ||
+            requiredRoles.every((role) => userRoles.has(role));
+
+        return hasPermissions && hasRoles;
+    });
     return (
         <SidebarGroup className="px-2 py-0">
             <SidebarGroupLabel>Platform</SidebarGroupLabel>
             <SidebarMenu>
-                {items.map((item) => (
+                {visibleItems.map((item) => (
                     <SidebarMenuItem key={item.title}>
                         <SidebarMenuButton
                             asChild

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -20,6 +20,8 @@ export interface NavItem {
     href: NonNullable<InertiaLinkProps['href']>;
     icon?: LucideIcon | null;
     isActive?: boolean;
+    permissions?: string[];
+    roles?: string[];
 }
 
 export interface SharedData {


### PR DESCRIPTION
## Summary
- allow nav items to declare required roles and permissions metadata
- filter the sidebar navigation so that restricted links are hidden when the user lacks access
- tag administrator-only links with the appropriate permission requirements
