### PR TITLE
feat: add inventory adjustment workflow

### DIFF
--- a/app/Http/Controllers/Inventory/InventoryAdjustmentController.php
+++ b/app/Http/Controllers/Inventory/InventoryAdjustmentController.php
@@ -1,0 +1,146 @@
+<?php
+
+namespace App\Http\Controllers\Inventory;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Inventory\StoreInventoryAdjustmentRequest;
+use App\Models\InventoryAdjustment;
+use App\Models\InventoryLevel;
+use App\Models\InventoryLocation;
+use App\Models\Product;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Redirect;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class InventoryAdjustmentController extends Controller
+{
+    public function index(): Response
+    {
+        $inventoryLocations = InventoryLocation::query()
+            ->orderBy('name')
+            ->get()
+            ->map(fn (InventoryLocation $location): array => [
+                'id' => $location->id,
+                'name' => $location->name,
+                'code' => $location->code,
+                'is_default' => $location->is_default,
+            ]);
+
+        $products = Product::query()
+            ->with('inventoryLevels')
+            ->orderBy('name')
+            ->get()
+            ->map(function (Product $product): array {
+                return [
+                    'id' => $product->id,
+                    'name' => $product->name,
+                    'barcode' => $product->barcode,
+                    'stock' => $product->stock,
+                    'inventory_levels' => $product->inventoryLevels
+                        ->map(fn (InventoryLevel $level): array => [
+                            'inventory_location_id' => $level->inventory_location_id,
+                            'quantity' => $level->quantity,
+                        ])->values()->all(),
+                ];
+            });
+
+        $adjustments = InventoryAdjustment::query()
+            ->with(['product', 'inventoryLocation', 'user'])
+            ->latest()
+            ->take(50)
+            ->get()
+            ->map(function (InventoryAdjustment $adjustment): array {
+                return [
+                    'id' => $adjustment->id,
+                    'quantity_delta' => $adjustment->quantity_delta,
+                    'reason' => $adjustment->reason,
+                    'notes' => $adjustment->notes,
+                    'created_at' => $adjustment->created_at?->toIso8601String(),
+                    'product' => [
+                        'id' => $adjustment->product->id,
+                        'name' => $adjustment->product->name,
+                        'barcode' => $adjustment->product->barcode,
+                        'stock' => $adjustment->product->stock,
+                    ],
+                    'location' => [
+                        'id' => $adjustment->inventoryLocation->id,
+                        'name' => $adjustment->inventoryLocation->name,
+                        'code' => $adjustment->inventoryLocation->code,
+                    ],
+                    'user' => [
+                        'id' => $adjustment->user->id,
+                        'name' => $adjustment->user->name,
+                    ],
+                ];
+            });
+
+        return Inertia::render('inventory/inventory-adjustments/index', [
+            'inventoryLocations' => $inventoryLocations,
+            'products' => $products,
+            'recentAdjustments' => $adjustments,
+        ]);
+    }
+
+    public function store(StoreInventoryAdjustmentRequest $request): RedirectResponse
+    {
+        $data = $request->validated();
+        $user = $request->user();
+
+        if (! $user) {
+            abort(403);
+        }
+
+        $userId = (int) $user->id;
+        $locationId = (int) $data['location_id'];
+
+        DB::transaction(function () use ($data, $userId, $locationId): void {
+            foreach ($data['adjustments'] as $payload) {
+                $product = Product::query()
+                    ->whereKey($payload['product_id'])
+                    ->lockForUpdate()
+                    ->first();
+
+                if (! $product) {
+                    continue;
+                }
+
+                $delta = (int) $payload['quantity_delta'];
+
+                $product->stock = (int) $product->stock + $delta;
+                $product->save();
+
+                $level = InventoryLevel::query()
+                    ->where('product_id', $product->id)
+                    ->where('inventory_location_id', $locationId)
+                    ->lockForUpdate()
+                    ->first();
+
+                if (! $level) {
+                    $level = new InventoryLevel();
+                    $level->product_id = $product->id;
+                    $level->inventory_location_id = $locationId;
+                    $level->quantity = 0;
+                }
+
+                $level->quantity = (int) $level->quantity + $delta;
+                $level->save();
+
+                $notesRaw = $payload['notes'] ?? null;
+                $notes = is_string($notesRaw) ? trim($notesRaw) : null;
+
+                InventoryAdjustment::create([
+                    'product_id' => $product->id,
+                    'inventory_location_id' => $locationId,
+                    'user_id' => $userId,
+                    'quantity_delta' => $delta,
+                    'reason' => $payload['reason'],
+                    'notes' => $notes !== '' ? $notes : null,
+                ]);
+            }
+        });
+
+        return Redirect::back()->with('success', 'Inventory adjustments saved successfully.');
+    }
+}

--- a/app/Http/Requests/Inventory/StoreInventoryAdjustmentRequest.php
+++ b/app/Http/Requests/Inventory/StoreInventoryAdjustmentRequest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Requests\Inventory;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreInventoryAdjustmentRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, array<int, mixed>>
+     */
+    public function rules(): array
+    {
+        return [
+            'location_id' => ['required', 'exists:inventory_locations,id'],
+            'adjustments' => ['required', 'array', 'min:1'],
+            'adjustments.*.product_id' => ['required', 'exists:products,id'],
+            'adjustments.*.quantity_delta' => ['required', 'integer', 'not_in:0'],
+            'adjustments.*.reason' => ['required', 'string', 'max:255'],
+            'adjustments.*.notes' => ['nullable', 'string'],
+        ];
+    }
+}

--- a/app/Models/InventoryAdjustment.php
+++ b/app/Models/InventoryAdjustment.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class InventoryAdjustment extends Model
+{
+    use HasFactory;
+
+    /**
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'product_id',
+        'inventory_location_id',
+        'user_id',
+        'quantity_delta',
+        'reason',
+        'notes',
+    ];
+
+    /**
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'quantity_delta' => 'integer',
+    ];
+
+    public function product(): BelongsTo
+    {
+        return $this->belongsTo(Product::class);
+    }
+
+    public function inventoryLocation(): BelongsTo
+    {
+        return $this->belongsTo(InventoryLocation::class);
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Models/InventoryLocation.php
+++ b/app/Models/InventoryLocation.php
@@ -25,6 +25,11 @@ class InventoryLocation extends Model
         return $this->hasMany(InventoryLevel::class);
     }
 
+    public function inventoryAdjustments(): HasMany
+    {
+        return $this->hasMany(InventoryAdjustment::class);
+    }
+
     public function lots(): HasMany
     {
         return $this->hasMany(ProductLot::class);

--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -62,6 +62,11 @@ class Product extends Model
         return $this->hasMany(InventoryLevel::class);
     }
 
+    public function inventoryAdjustments(): HasMany
+    {
+        return $this->hasMany(InventoryAdjustment::class);
+    }
+
     public function lots(): HasMany
     {
         return $this->hasMany(ProductLot::class);

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Laravel\Fortify\TwoFactorAuthenticatable;
@@ -46,5 +47,10 @@ class User extends Authenticatable
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
         ];
+    }
+
+    public function inventoryAdjustments(): HasMany
+    {
+        return $this->hasMany(InventoryAdjustment::class);
     }
 }

--- a/database/migrations/2025_10_15_000100_create_inventory_adjustments_table.php
+++ b/database/migrations/2025_10_15_000100_create_inventory_adjustments_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('inventory_adjustments', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('product_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('inventory_location_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->integer('quantity_delta');
+            $table->string('reason');
+            $table->text('notes')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('inventory_adjustments');
+    }
+};

--- a/resources/js/components/app-sidebar.tsx
+++ b/resources/js/components/app-sidebar.tsx
@@ -15,6 +15,7 @@ import { type NavItem } from '@/types';
 import { Link } from '@inertiajs/react';
 import {
     BookOpen,
+    Boxes,
     ClipboardList,
     Factory,
     Folder,
@@ -61,6 +62,11 @@ const mainNavItems: NavItem[] = [
         title: 'Suppliers',
         href: '/inventory/suppliers',
         icon: Factory,
+    },
+    {
+        title: 'Inventory Adjustments',
+        href: '/inventory/adjustments',
+        icon: Boxes,
     },
     {
         title: 'Purchase Orders',

--- a/resources/js/pages/inventory/inventory-adjustments/index.tsx
+++ b/resources/js/pages/inventory/inventory-adjustments/index.tsx
@@ -1,0 +1,541 @@
+import InputError from '@/components/input-error';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from '@/components/ui/select';
+import AppLayout from '@/layouts/app-layout';
+import { type BreadcrumbItem, type SharedData } from '@/types';
+import { Head, useForm, usePage } from '@inertiajs/react';
+import { ChangeEvent, FormEvent, useMemo, useState } from 'react';
+import {
+    ArrowLeftRight,
+    Boxes,
+    History,
+    ListPlus,
+    PackageSearch,
+    Trash2,
+} from 'lucide-react';
+
+interface InventoryLocationSummary {
+    id: number;
+    name: string;
+    code: string;
+    is_default: boolean;
+}
+
+interface ProductInventoryLevel {
+    inventory_location_id: number;
+    quantity: number;
+}
+
+interface ProductSummary {
+    id: number;
+    name: string;
+    barcode: string;
+    stock: number;
+    inventory_levels: ProductInventoryLevel[];
+}
+
+interface RecentAdjustmentSummary {
+    id: number;
+    quantity_delta: number;
+    reason: string;
+    notes: string | null;
+    created_at: string | null;
+    product: {
+        id: number;
+        name: string;
+        barcode: string;
+        stock: number;
+    };
+    location: {
+        id: number;
+        name: string;
+        code: string;
+    };
+    user: {
+        id: number;
+        name: string;
+    };
+}
+
+interface InventoryAdjustmentsPageProps {
+    inventoryLocations: InventoryLocationSummary[];
+    products: ProductSummary[];
+    recentAdjustments: RecentAdjustmentSummary[];
+}
+
+interface DraftAdjustment {
+    productId: string;
+    quantityDelta: string;
+    reason: string;
+    notes: string;
+}
+
+const breadcrumbs: BreadcrumbItem[] = [
+    {
+        title: 'Inventory Adjustments',
+        href: '/inventory/adjustments',
+    },
+];
+
+const formatDate = (value: string | null): string => {
+    if (!value) {
+        return '—';
+    }
+
+    const date = new Date(value);
+
+    if (Number.isNaN(date.getTime())) {
+        return '—';
+    }
+
+    return date.toLocaleString();
+};
+
+export default function InventoryAdjustmentsIndex({
+    inventoryLocations,
+    products,
+    recentAdjustments,
+}: InventoryAdjustmentsPageProps) {
+    const { flash } = usePage<SharedData>().props;
+
+    const defaultLocationId = useMemo(() => {
+        const preferred = inventoryLocations.find((location) => location.is_default);
+
+        return preferred?.id.toString() ?? inventoryLocations[0]?.id.toString() ?? '';
+    }, [inventoryLocations]);
+
+    const form = useForm<{
+        location_id: string;
+        adjustments: { product_id: number; quantity_delta: number; reason: string; notes: string }[];
+    }>({
+        location_id: defaultLocationId,
+        adjustments: [],
+    });
+
+    const [searchTerm, setSearchTerm] = useState('');
+    const [draft, setDraft] = useState<DraftAdjustment>({
+        productId: '',
+        quantityDelta: '',
+        reason: '',
+        notes: '',
+    });
+
+    const selectedProduct = useMemo(() => {
+        if (!draft.productId) {
+            return undefined;
+        }
+
+        const id = Number.parseInt(draft.productId, 10);
+
+        if (Number.isNaN(id)) {
+            return undefined;
+        }
+
+        return products.find((product) => product.id === id);
+    }, [draft.productId, products]);
+
+    const selectedLocationQuantity = useMemo(() => {
+        if (!selectedProduct) {
+            return 0;
+        }
+
+        const locationId = Number.parseInt(form.data.location_id, 10);
+
+        if (Number.isNaN(locationId)) {
+            return 0;
+        }
+
+        return (
+            selectedProduct.inventory_levels.find(
+                (level) => level.inventory_location_id === locationId,
+            )?.quantity ?? 0
+        );
+    }, [form.data.location_id, selectedProduct]);
+
+    const filteredProducts = useMemo(() => {
+        const term = searchTerm.trim().toLowerCase();
+
+        if (!term) {
+            return products.slice(0, 25);
+        }
+
+        return products
+            .filter((product) => {
+                return (
+                    product.name.toLowerCase().includes(term) ||
+                    product.barcode.toLowerCase().includes(term)
+                );
+            })
+            .slice(0, 25);
+    }, [products, searchTerm]);
+
+    const adjustmentErrors = useMemo(() => {
+        return Object.entries(form.errors)
+            .filter(([key]) => key.startsWith('adjustments'))
+            .map(([, message]) => message);
+    }, [form.errors]);
+
+    const handleLocationChange = (value: string) => {
+        form.setData('location_id', value);
+    };
+
+    const handleSearchChange = (event: ChangeEvent<HTMLInputElement>) => {
+        setSearchTerm(event.target.value);
+    };
+
+    const handleDraftChange = <Field extends keyof DraftAdjustment>(
+        field: Field,
+        value: DraftAdjustment[Field],
+    ) => {
+        setDraft((current) => ({ ...current, [field]: value }));
+    };
+
+    const handleAddAdjustment = () => {
+        if (!draft.productId) {
+            return;
+        }
+
+        const quantity = Number.parseInt(draft.quantityDelta, 10);
+
+        if (!Number.isFinite(quantity) || quantity === 0) {
+            return;
+        }
+
+        const productId = Number.parseInt(draft.productId, 10);
+
+        if (Number.isNaN(productId)) {
+            return;
+        }
+
+        const next = [
+            ...form.data.adjustments,
+            {
+                product_id: productId,
+                quantity_delta: quantity,
+                reason: draft.reason.trim() || 'manual adjustment',
+                notes: draft.notes.trim(),
+            },
+        ];
+
+        form.setData('adjustments', next);
+        setDraft({ productId: draft.productId, quantityDelta: '', reason: '', notes: '' });
+    };
+
+    const handleRemoveAdjustment = (index: number) => {
+        const next = form.data.adjustments.filter((_, idx) => idx !== index);
+        form.setData('adjustments', next);
+    };
+
+    const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+        event.preventDefault();
+
+        if (form.data.adjustments.length === 0) {
+            return;
+        }
+
+        form.post('/inventory/adjustments', {
+            preserveScroll: true,
+            onSuccess: () => {
+                form.setData('adjustments', []);
+                setDraft({ productId: '', quantityDelta: '', reason: '', notes: '' });
+                setSearchTerm('');
+            },
+        });
+    };
+
+    return (
+        <AppLayout breadcrumbs={breadcrumbs}>
+            <Head title="Inventory Adjustments" />
+
+            <div className="space-y-6 p-4">
+                {flash?.success && (
+                    <Alert className="border-green-200 bg-green-50 text-green-900 dark:border-green-900/40 dark:bg-green-900/20 dark:text-green-100">
+                        <AlertTitle>Success</AlertTitle>
+                        <AlertDescription>{flash.success}</AlertDescription>
+                    </Alert>
+                )}
+
+                {flash?.error && (
+                    <Alert className="border-red-200 bg-red-50 text-red-800 dark:border-red-900/40 dark:bg-red-900/20 dark:text-red-100">
+                        <AlertTitle>Action required</AlertTitle>
+                        <AlertDescription>{flash.error}</AlertDescription>
+                    </Alert>
+                )}
+
+                <div className="grid gap-6 xl:grid-cols-[minmax(0,420px)_minmax(0,1fr)]">
+                    <form onSubmit={handleSubmit} className="space-y-6">
+                        <Card className="shadow-sm">
+                            <CardHeader className="space-y-2">
+                                <div className="flex items-center gap-2">
+                                    <ListPlus className="h-5 w-5" />
+                                    <CardTitle>Record adjustments</CardTitle>
+                                </div>
+                                <p className="text-sm text-muted-foreground">
+                                    Choose a location, select the products you counted, and log the variance with a reason for audit tracking.
+                                </p>
+                            </CardHeader>
+                            <CardContent className="space-y-4">
+                                <div className="space-y-2">
+                                    <Label htmlFor="location">Inventory location</Label>
+                                    <Select
+                                        value={form.data.location_id}
+                                        onValueChange={handleLocationChange}
+                                    >
+                                        <SelectTrigger id="location">
+                                            <SelectValue placeholder="Select location" />
+                                        </SelectTrigger>
+                                        <SelectContent>
+                                            {inventoryLocations.map((location) => (
+                                                <SelectItem key={location.id} value={location.id.toString()}>
+                                                    {location.name} ({location.code})
+                                                </SelectItem>
+                                            ))}
+                                        </SelectContent>
+                                    </Select>
+                                    <InputError message={form.errors.location_id} />
+                                </div>
+
+                                <div className="space-y-2">
+                                    <Label htmlFor="product-search">Find a product</Label>
+                                    <div className="flex items-center gap-2">
+                                        <Input
+                                            id="product-search"
+                                            value={searchTerm}
+                                            onChange={handleSearchChange}
+                                            placeholder="Search by name or barcode"
+                                            autoComplete="off"
+                                        />
+                                        <PackageSearch className="h-5 w-5 text-muted-foreground" />
+                                    </div>
+                                    <div className="max-h-56 overflow-y-auto rounded-md border border-border/60 bg-background">
+                                        {filteredProducts.length === 0 && (
+                                            <p className="p-3 text-sm text-muted-foreground">
+                                                No products matched your search.
+                                            </p>
+                                        )}
+
+                                        {filteredProducts.map((product) => {
+                                            const isSelected = draft.productId === product.id.toString();
+
+                                            return (
+                                                <Button
+                                                    key={product.id}
+                                                    type="button"
+                                                    variant={isSelected ? 'secondary' : 'ghost'}
+                                                    className="h-auto w-full justify-between px-3 py-2"
+                                                    onClick={() =>
+                                                        handleDraftChange('productId', product.id.toString())
+                                                    }
+                                                >
+                                                    <span className="flex flex-col items-start">
+                                                        <span className="text-sm font-medium">{product.name}</span>
+                                                        <span className="text-xs text-muted-foreground">
+                                                            {product.barcode || '—'}
+                                                        </span>
+                                                    </span>
+                                                    <Badge variant="outline">{product.stock} on hand</Badge>
+                                                </Button>
+                                            );
+                                        })}
+                                    </div>
+                                </div>
+
+                                {selectedProduct && (
+                                    <div className="rounded-lg border border-dashed border-border/60 bg-muted/30 p-4 text-sm">
+                                        <div className="flex items-center gap-2 text-muted-foreground">
+                                            <Boxes className="h-4 w-4" />
+                                            <span>
+                                                {selectedProduct.name} currently has
+                                                <span className="mx-1 font-semibold text-foreground">
+                                                    {selectedLocationQuantity}
+                                                </span>
+                                                units at this location (global stock {selectedProduct.stock}).
+                                            </span>
+                                        </div>
+                                    </div>
+                                )}
+
+                                <div className="grid gap-4 sm:grid-cols-2">
+                                    <div className="space-y-2">
+                                        <Label htmlFor="quantity-delta">Quantity change</Label>
+                                        <Input
+                                            id="quantity-delta"
+                                            value={draft.quantityDelta}
+                                            onChange={(event) =>
+                                                handleDraftChange('quantityDelta', event.target.value)
+                                            }
+                                            placeholder="e.g. -3 or 5"
+                                        />
+                                    </div>
+                                    <div className="space-y-2">
+                                        <Label htmlFor="reason">Reason</Label>
+                                        <Input
+                                            id="reason"
+                                            value={draft.reason}
+                                            onChange={(event) => handleDraftChange('reason', event.target.value)}
+                                            placeholder="Damaged, cycle count, etc."
+                                        />
+                                    </div>
+                                </div>
+
+                                <div className="space-y-2">
+                                    <Label htmlFor="notes">Notes (optional)</Label>
+                                    <Input
+                                        id="notes"
+                                        value={draft.notes}
+                                        onChange={(event) => handleDraftChange('notes', event.target.value)}
+                                        placeholder="Add context for the adjustment"
+                                    />
+                                </div>
+
+                                <div className="flex items-center justify-between">
+                                    <Button
+                                        type="button"
+                                        variant="outline"
+                                        onClick={() => setDraft({ productId: '', quantityDelta: '', reason: '', notes: '' })}
+                                    >
+                                        <ArrowLeftRight className="mr-2 h-4 w-4" />Reset selection
+                                    </Button>
+                                    <Button type="button" onClick={handleAddAdjustment}>
+                                        <ListPlus className="mr-2 h-4 w-4" />
+                                        Add to batch
+                                    </Button>
+                                </div>
+
+                                {adjustmentErrors.length > 0 && (
+                                    <div className="space-y-2 rounded-md border border-destructive/60 bg-destructive/10 p-3 text-sm text-destructive">
+                                        {adjustmentErrors.map((message, index) => (
+                                            <p key={`${message}-${index}`}>{message}</p>
+                                        ))}
+                                    </div>
+                                )}
+
+                                <div className="space-y-3">
+                                    <div className="flex items-center gap-2">
+                                        <History className="h-4 w-4" />
+                                        <span className="text-sm font-semibold">Pending adjustments</span>
+                                    </div>
+                                    {form.data.adjustments.length === 0 ? (
+                                        <p className="text-sm text-muted-foreground">
+                                            Add products above to prepare a batch adjustment.
+                                        </p>
+                                    ) : (
+                                        <div className="space-y-2">
+                                            {form.data.adjustments.map((adjustment, index) => {
+                                                const product = products.find(
+                                                    (candidate) => candidate.id === adjustment.product_id,
+                                                );
+
+                                                return (
+                                                    <div
+                                                        key={`${adjustment.product_id}-${index}`}
+                                                        className="flex items-center justify-between rounded-md border border-border/60 bg-background px-3 py-2"
+                                                    >
+                                                        <div className="space-y-1">
+                                                            <p className="text-sm font-medium">
+                                                                {product?.name ?? 'Unknown product'}
+                                                            </p>
+                                                            <p className="text-xs text-muted-foreground">
+                                                                {adjustment.quantity_delta > 0 ? '+' : ''}
+                                                                {adjustment.quantity_delta} &middot; {adjustment.reason}
+                                                                {adjustment.notes && ` — ${adjustment.notes}`}
+                                                            </p>
+                                                        </div>
+                                                        <Button
+                                                            type="button"
+                                                            variant="ghost"
+                                                            size="icon"
+                                                            onClick={() => handleRemoveAdjustment(index)}
+                                                        >
+                                                            <Trash2 className="h-4 w-4" />
+                                                        </Button>
+                                                    </div>
+                                                );
+                                            })}
+                                        </div>
+                                    )}
+                                </div>
+
+                                <div className="flex justify-end">
+                                    <Button type="submit" disabled={form.processing || form.data.adjustments.length === 0}>
+                                        <ArrowLeftRight className="mr-2 h-4 w-4" />
+                                        Post adjustments
+                                    </Button>
+                                </div>
+                            </CardContent>
+                        </Card>
+                    </form>
+
+                    <div className="space-y-4">
+                        <Card className="shadow-sm">
+                            <CardHeader className="space-y-1">
+                                <div className="flex items-center gap-2">
+                                    <History className="h-5 w-5" />
+                                    <CardTitle>Recent activity</CardTitle>
+                                </div>
+                                <p className="text-sm text-muted-foreground">
+                                    The 50 most recent adjustments across all locations.
+                                </p>
+                            </CardHeader>
+                            <CardContent className="space-y-4">
+                                {recentAdjustments.length === 0 ? (
+                                    <p className="text-sm text-muted-foreground">
+                                        No adjustments have been recorded yet.
+                                    </p>
+                                ) : (
+                                    <div className="space-y-3">
+                                        {recentAdjustments.map((adjustment) => (
+                                            <div
+                                                key={adjustment.id}
+                                                className="rounded-md border border-border/60 bg-background p-3"
+                                            >
+                                                <div className="flex flex-wrap items-center justify-between gap-2">
+                                                    <div>
+                                                        <p className="text-sm font-semibold">
+                                                            {adjustment.product.name}
+                                                            <span className="ml-2 text-xs text-muted-foreground">
+                                                                {adjustment.product.barcode || '—'}
+                                                            </span>
+                                                        </p>
+                                                        <p className="text-xs text-muted-foreground">
+                                                            {formatDate(adjustment.created_at)} &middot; {adjustment.user.name}
+                                                        </p>
+                                                    </div>
+                                                    <Badge variant={adjustment.quantity_delta >= 0 ? 'secondary' : 'destructive'}>
+                                                        {adjustment.quantity_delta > 0 ? '+' : ''}
+                                                        {adjustment.quantity_delta}
+                                                    </Badge>
+                                                </div>
+                                                <div className="mt-2 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+                                                    <span className="flex items-center gap-1">
+                                                        <Boxes className="h-3 w-3" />
+                                                        {adjustment.location.name} ({adjustment.location.code})
+                                                    </span>
+                                                    <Badge variant="outline" className="text-xs">
+                                                        {adjustment.reason}
+                                                    </Badge>
+                                                    {adjustment.notes && <span>— {adjustment.notes}</span>}
+                                                </div>
+                                            </div>
+                                        ))}
+                                    </div>
+                                )}
+                            </CardContent>
+                        </Card>
+                    </div>
+                </div>
+            </div>
+        </AppLayout>
+    );
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\Inventory\InventoryAdjustmentController;
 use App\Http\Controllers\Inventory\PurchaseOrderController;
 use App\Http\Controllers\Inventory\SupplierController;
 use App\Http\Controllers\DashboardController;
@@ -41,6 +42,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
         Route::resource('purchase-orders', PurchaseOrderController::class)->only(['index', 'store', 'update', 'destroy']);
         Route::post('purchase-orders/{purchaseOrder}/receive', [PurchaseOrderController::class, 'receive'])
             ->name('purchase-orders.receive');
+        Route::resource('adjustments', InventoryAdjustmentController::class)->only(['index', 'store']);
     });
 });
 

--- a/tests/Feature/Inventory/InventoryAdjustmentControllerTest.php
+++ b/tests/Feature/Inventory/InventoryAdjustmentControllerTest.php
@@ -1,0 +1,168 @@
+<?php
+
+use App\Models\InventoryAdjustment;
+use App\Models\InventoryLevel;
+use App\Models\InventoryLocation;
+use App\Models\Product;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use Inertia\Testing\AssertableInertia as Assert;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function (): void {
+    $this->withoutVite();
+});
+
+function createInventoryLocation(array $attributes = []): InventoryLocation
+{
+    return InventoryLocation::query()->create(array_merge([
+        'name' => 'Main Stockroom',
+        'code' => 'MS',
+        'is_default' => false,
+    ], $attributes));
+}
+
+function createInventoryProduct(array $attributes = []): Product
+{
+    return Product::query()->create(array_merge([
+        'supplier_id' => null,
+        'barcode' => 'PRD-' . Str::upper(Str::random(8)),
+        'supplier_sku' => null,
+        'name' => 'Adjustment Test Product',
+        'stock' => 0,
+        'price' => 10.0,
+        'cost_price' => 5.0,
+        'image_path' => null,
+        'reorder_point' => null,
+        'reorder_quantity' => null,
+    ], $attributes));
+}
+
+test('inventory adjustments index includes locations, products, and audit history', function (): void {
+    $user = User::factory()->create();
+    $location = createInventoryLocation(['name' => 'Front Store', 'code' => 'FS', 'is_default' => true]);
+    $product = createInventoryProduct(['name' => 'Widget A', 'stock' => 12]);
+
+    InventoryLevel::query()->create([
+        'product_id' => $product->id,
+        'inventory_location_id' => $location->id,
+        'quantity' => 6,
+    ]);
+
+    $adjustment = InventoryAdjustment::query()->create([
+        'product_id' => $product->id,
+        'inventory_location_id' => $location->id,
+        'user_id' => $user->id,
+        'quantity_delta' => -2,
+        'reason' => 'Cycle count',
+        'notes' => 'Damaged unit removed',
+    ]);
+
+    $this->actingAs($user)
+        ->get(route('inventory.adjustments.index'))
+        ->assertOk()
+        ->assertInertia(fn (Assert $page) => $page
+            ->component('inventory/inventory-adjustments/index')
+            ->where('inventoryLocations', fn ($locations): bool => collect($locations)->contains(
+                fn ($item) => $item['id'] === $location->id
+                    && $item['name'] === 'Front Store'
+                    && $item['code'] === 'FS'
+                    && $item['is_default'] === true,
+            ))
+            ->has('products', fn (Assert $collection) => $collection
+                ->has(0, fn (Assert $productAssert) => $productAssert
+                    ->where('id', $product->id)
+                    ->where('name', 'Widget A')
+                    ->where('stock', 12)
+                    ->has('inventory_levels', fn (Assert $levels) => $levels
+                        ->has(0, fn (Assert $level) => $level
+                            ->where('inventory_location_id', $location->id)
+                            ->where('quantity', 6)
+                            ->etc()
+                        )
+                        ->etc()
+                    )
+                    ->etc()
+                )
+            )
+            ->has('recentAdjustments', fn (Assert $collection) => $collection
+                ->has(0, fn (Assert $adjustmentAssert) => $adjustmentAssert
+                    ->where('id', $adjustment->id)
+                    ->where('quantity_delta', -2)
+                    ->where('reason', 'Cycle count')
+                    ->where('notes', 'Damaged unit removed')
+                    ->where('product.id', $product->id)
+                    ->where('location.id', $location->id)
+                    ->where('user.id', $user->id)
+                    ->etc()
+                )
+            )
+        );
+});
+
+test('posting adjustments updates product stock and inventory level', function (): void {
+    $user = User::factory()->create();
+    $location = createInventoryLocation(['name' => 'Warehouse', 'code' => 'WH']);
+    $product = createInventoryProduct(['stock' => 10]);
+
+    InventoryLevel::query()->create([
+        'product_id' => $product->id,
+        'inventory_location_id' => $location->id,
+        'quantity' => 4,
+    ]);
+
+    $payload = [
+        'location_id' => $location->id,
+        'adjustments' => [
+            [
+                'product_id' => $product->id,
+                'quantity_delta' => 5,
+                'reason' => 'Cycle count',
+                'notes' => 'Overstock discovered',
+            ],
+            [
+                'product_id' => $product->id,
+                'quantity_delta' => -2,
+                'reason' => 'Damage',
+                'notes' => 'Broken packaging',
+            ],
+        ],
+    ];
+
+    $response = $this->actingAs($user)
+        ->from(route('inventory.adjustments.index'))
+        ->post(route('inventory.adjustments.store'), $payload);
+
+    $response->assertRedirect(route('inventory.adjustments.index'));
+
+    $product->refresh();
+    $level = InventoryLevel::query()
+        ->where('product_id', $product->id)
+        ->where('inventory_location_id', $location->id)
+        ->first();
+
+    expect($product->stock)->toBe(13)
+        ->and($level)->not->toBeNull()
+        ->and($level->quantity)->toBe(7)
+        ->and(InventoryAdjustment::count())->toBe(2);
+
+    $entries = InventoryAdjustment::query()->orderBy('id')->get();
+
+    expect($entries->first())->toMatchArray([
+        'product_id' => $product->id,
+        'inventory_location_id' => $location->id,
+        'user_id' => $user->id,
+        'quantity_delta' => 5,
+        'reason' => 'Cycle count',
+        'notes' => 'Overstock discovered',
+    ]);
+
+    expect($entries->last())->toMatchArray([
+        'quantity_delta' => -2,
+        'reason' => 'Damage',
+        'notes' => 'Broken packaging',
+    ]);
+});
+

--- a/tests/Unit/InventoryAdjustmentTest.php
+++ b/tests/Unit/InventoryAdjustmentTest.php
@@ -1,0 +1,65 @@
+<?php
+
+use App\Models\InventoryAdjustment;
+use App\Models\InventoryLocation;
+use App\Models\Product;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+uses(TestCase::class, RefreshDatabase::class);
+
+beforeEach(function (): void {
+    $this->withoutVite();
+});
+
+function createAdjustmentProduct(array $attributes = []): Product
+{
+    return Product::query()->create(array_merge([
+        'supplier_id' => null,
+        'barcode' => 'PRD-' . Str::upper(Str::random(8)),
+        'supplier_sku' => null,
+        'name' => 'Unit Test Product',
+        'stock' => 0,
+        'price' => 12.5,
+        'cost_price' => 6.0,
+        'image_path' => null,
+        'reorder_point' => null,
+        'reorder_quantity' => null,
+    ], $attributes));
+}
+
+function createAdjustmentLocation(array $attributes = []): InventoryLocation
+{
+    return InventoryLocation::query()->create(array_merge([
+        'name' => 'Unit Test Location',
+        'code' => 'UTL',
+        'is_default' => false,
+    ], $attributes));
+}
+
+test('inventory adjustments expose their related product, location, and user', function (): void {
+    $user = User::factory()->create(['name' => 'Auditor']);
+    $product = createAdjustmentProduct();
+    $location = createAdjustmentLocation();
+
+    $adjustment = InventoryAdjustment::query()->create([
+        'product_id' => $product->id,
+        'inventory_location_id' => $location->id,
+        'user_id' => $user->id,
+        'quantity_delta' => '3',
+        'reason' => 'Cycle count',
+        'notes' => 'Reconciled during audit',
+    ]);
+
+    expect($adjustment->product)->toBeInstanceOf(Product::class)
+        ->and($adjustment->product->is($product))->toBeTrue()
+        ->and($adjustment->inventoryLocation)->toBeInstanceOf(InventoryLocation::class)
+        ->and($adjustment->inventoryLocation->is($location))->toBeTrue()
+        ->and($adjustment->user)->toBeInstanceOf(User::class)
+        ->and($adjustment->user->is($user))->toBeTrue()
+        ->and($adjustment->quantity_delta)->toBe(3);
+});
+
+


### PR DESCRIPTION
## Summary
- add an inventory_adjustments table and Eloquent model connected to products, locations, and users
- implement an InventoryAdjustmentController plus request validation that records adjustments and updates stock levels
- build an inventory adjustments Inertia page and navigation link, and add feature/unit tests for the workflow

## Testing
- php artisan test --filter=InventoryAdjustmentControllerTest
- php artisan test --filter=InventoryAdjustmentTest
- npm run types *(fails: existing missing route modules and auth typing issues)*

------
https://chatgpt.com/codex/tasks/task_e_68dcd3a2b138832f8ee207b9d2a8c5a1