### PR TITLE
Add supplier performance analytics to dashboard

### DIFF
--- a/app/Console/Commands/WarmDashboardMetricsCommand.php
+++ b/app/Console/Commands/WarmDashboardMetricsCommand.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Services\DashboardMetricsService;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Cache;
+
+class WarmDashboardMetricsCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'dashboard:warm {--days=* : Day ranges to warm}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Warm the cached dashboard analytics metrics for faster rendering.';
+
+    public function handle(DashboardMetricsService $metricsService): int
+    {
+        $ranges = collect($this->option('days'))
+            ->filter(static fn ($value) => $value !== null && $value !== '')
+            ->map(static fn ($value) => (int) $value)
+            ->filter(static fn (int $value) => $value > 0)
+            ->unique()
+            ->values();
+
+        if ($ranges->isEmpty()) {
+            $default = (int) config('store.dashboard.default_range_days', 14);
+            $ranges = collect([$default, 30]);
+        }
+
+        $cacheMinutes = (int) config('store.dashboard.cache_minutes', 5);
+
+        foreach ($ranges as $days) {
+            $cacheKey = sprintf('dashboard:metrics:%d', $days);
+
+            Cache::forget($cacheKey);
+            Cache::remember($cacheKey, now()->addMinutes($cacheMinutes), fn () => $metricsService->build($days));
+
+            $this->info(sprintf('Warmed dashboard metrics for %d-day range.', $days));
+        }
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -2,10 +2,7 @@
 
 namespace App\Http\Controllers;
 
-use App\Models\Product;
-use App\Models\Transaction;
-use App\Models\TransactionItem;
-use Carbon\CarbonImmutable;
+use App\Services\DashboardMetricsService;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Cache;
 use Inertia\Inertia;
@@ -13,6 +10,10 @@ use Inertia\Response;
 
 class DashboardController extends Controller
 {
+    public function __construct(private readonly DashboardMetricsService $metricsService)
+    {
+    }
+
     public function __invoke(Request $request): Response
     {
         $defaultDays = (int) config('store.dashboard.default_range_days', 14);
@@ -24,178 +25,7 @@ class DashboardController extends Controller
         $metrics = Cache::remember(
             $cacheKey,
             now()->addMinutes($cacheMinutes),
-            function () use ($days) {
-                $end = CarbonImmutable::now()->endOfDay();
-                $start = $end->subDays($days - 1)->startOfDay();
-
-                $aggregate = Transaction::query()
-                    ->withinPeriod($start, $end)
-                    ->selectRaw('SUM(total) as revenue')
-                    ->selectRaw('SUM(subtotal) as subtotal')
-                    ->selectRaw('SUM(tax_total) as tax_total')
-                    ->selectRaw('SUM(discount_total) as discount_total')
-                    ->selectRaw('COUNT(*) as transactions')
-                    ->selectRaw('SUM(items_count) as items')
-                    ->selectRaw('SUM(CASE WHEN tax_total > 0 THEN 1 ELSE 0 END) as taxed_transactions')
-                    ->first();
-
-                $revenue = (float) ($aggregate?->revenue ?? 0);
-                $transactions = (int) ($aggregate?->transactions ?? 0);
-                $items = (int) ($aggregate?->items ?? 0);
-                $subtotal = (float) ($aggregate?->subtotal ?? 0);
-                $taxTotal = (float) ($aggregate?->tax_total ?? 0);
-                $discountTotal = (float) ($aggregate?->discount_total ?? 0);
-                $taxedTransactions = (int) ($aggregate?->taxed_transactions ?? 0);
-
-                $averageBasket = $transactions > 0 ? round($items / $transactions, 2) : 0.0;
-
-                $itemCostAggregate = TransactionItem::query()
-                    ->whereHas('transaction', static function ($query) use ($start, $end): void {
-                        $query->withinPeriod($start, $end);
-                    })
-                    ->selectRaw('COALESCE(SUM(line_cost), 0) as cost')
-                    ->first();
-
-                $totalCost = (float) ($itemCostAggregate?->cost ?? 0.0);
-                $grossProfit = round($revenue - $totalCost, 2);
-                $grossMargin = $revenue > 0 ? round($grossProfit / $revenue, 4) : 0.0;
-
-                $itemCostsSubquery = TransactionItem::query()
-                    ->selectRaw('transaction_id, COALESCE(SUM(line_cost), 0) as total_cost')
-                    ->groupBy('transaction_id');
-
-                $dailySales = Transaction::query()
-                    ->withinPeriod($start, $end)
-                    ->leftJoinSub($itemCostsSubquery, 'item_costs', 'transactions.id', '=', 'item_costs.transaction_id')
-                    ->selectRaw('DATE(transactions.created_at) as date')
-                    ->selectRaw('SUM(transactions.total) as revenue')
-                    ->selectRaw('COUNT(*) as transactions')
-                    ->selectRaw('SUM(transactions.items_count) as items')
-                    ->selectRaw('COALESCE(SUM(item_costs.total_cost), 0) as cost')
-                    ->groupByRaw('DATE(transactions.created_at)')
-                    ->orderBy('date')
-                    ->get()
-                    ->map(static function ($row) {
-                        $transactions = (int) $row->transactions;
-                        $items = (int) $row->items;
-                        $revenue = (float) $row->revenue;
-                        $cost = (float) $row->cost;
-                        $profit = round($revenue - $cost, 2);
-
-                        return [
-                            'date' => $row->date,
-                            'revenue' => $revenue,
-                            'transactions' => $transactions,
-                            'items' => $items,
-                            'cost' => $cost,
-                            'profit' => $profit,
-                            'averageBasketSize' => $transactions > 0
-                                ? round($items / $transactions, 2)
-                                : 0.0,
-                        ];
-                    })
-                    ->values()
-                    ->all();
-
-                $topSelling = TransactionItem::query()
-                    ->whereHas('transaction', static function ($query) use ($start, $end): void {
-                        $query->withinPeriod($start, $end);
-                    })
-                    ->topSelling()
-                    ->get()
-                    ->map(static function ($row) {
-                        $revenue = (float) $row->revenue;
-                        $cost = (float) $row->cost;
-                        $profit = round($revenue - $cost, 2);
-                        $margin = $revenue > 0 ? round($profit / $revenue, 4) : 0.0;
-
-                        return [
-                            'name' => $row->name,
-                            'quantity' => (int) $row->quantity,
-                            'revenue' => $revenue,
-                            'cost' => $cost,
-                            'profit' => $profit,
-                            'profitMargin' => $margin,
-                        ];
-                    })
-                    ->values()
-                    ->all();
-
-                $defaultReorderPoint = (int) config('store.inventory.low_stock_threshold', 10);
-
-                $lowStockQuery = Product::query()->belowReorderPoint($defaultReorderPoint);
-                $lowStockCount = (clone $lowStockQuery)->count();
-
-                $lowStockProducts = (clone $lowStockQuery)
-                    ->select(['id', 'name', 'stock', 'reorder_point', 'reorder_quantity'])
-                    ->orderBy('stock')
-                    ->orderBy('name')
-                    ->limit(5)
-                    ->get()
-                    ->map(static function (Product $product) use ($defaultReorderPoint) {
-                        return [
-                            'id' => $product->id,
-                            'name' => $product->name,
-                            'stock' => $product->stock,
-                            'reorderPoint' => $product->reorder_point,
-                            'effectiveReorderPoint' => $product->effectiveReorderPoint($defaultReorderPoint),
-                            'reorderQuantity' => $product->reorder_quantity,
-                        ];
-                    })
-                    ->values()
-                    ->all();
-
-                $customReorderCount = Product::query()->whereNotNull('reorder_point')->count();
-
-                $averageDailyRevenue = $days > 0 ? round($revenue / $days, 2) : 0.0;
-                $averageDailyProfit = $days > 0 ? round($grossProfit / $days, 2) : 0.0;
-                $averageDailyTax = $days > 0 ? round($taxTotal / $days, 2) : 0.0;
-
-                return [
-                    'totals' => [
-                        'revenue' => $revenue,
-                        'transactions' => $transactions,
-                        'itemsSold' => $items,
-                        'averageBasketSize' => $averageBasket,
-                        'lowStockCount' => $lowStockCount,
-                        'totalCost' => $totalCost,
-                        'grossProfit' => $grossProfit,
-                        'grossMargin' => $grossMargin,
-                        'taxCollected' => $taxTotal,
-                    ],
-                    'dailySales' => $dailySales,
-                    'topSelling' => $topSelling,
-                    'lowStockThreshold' => $defaultReorderPoint,
-                    'customReorderCount' => $customReorderCount,
-                    'lowStockProducts' => $lowStockProducts,
-                    'taxSummary' => [
-                        'taxableSales' => $subtotal,
-                        'taxCollected' => $taxTotal,
-                        'discounts' => $discountTotal,
-                        'effectiveTaxRate' => $subtotal > 0 ? round($taxTotal / $subtotal, 4) : 0.0,
-                        'transactionsWithTax' => $taxedTransactions,
-                        'averageTaxPerTransaction' => $transactions > 0
-                            ? round($taxTotal / $transactions, 2)
-                            : 0.0,
-                    ],
-                    'forecast' => [
-                        'daysEvaluated' => $days,
-                        'averageDailyRevenue' => $averageDailyRevenue,
-                        'averageDailyProfit' => $averageDailyProfit,
-                        'averageDailyTax' => $averageDailyTax,
-                        'projectedRevenue30' => round($averageDailyRevenue * 30, 2),
-                        'projectedProfit30' => round($averageDailyProfit * 30, 2),
-                        'projectedTax30' => round($averageDailyTax * 30, 2),
-                    ],
-                    'currency' => config('app.currency', 'IDR'),
-                    'lastUpdated' => CarbonImmutable::now()->toIso8601String(),
-                    'range' => [
-                        'start' => $start->toDateString(),
-                        'end' => $end->toDateString(),
-                        'days' => $days,
-                    ],
-                ];
-            }
+            fn () => $this->metricsService->build($days)
         );
 
         return Inertia::render('dashboard', [

--- a/app/Models/PurchaseOrder.php
+++ b/app/Models/PurchaseOrder.php
@@ -2,10 +2,12 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Carbon;
 
 class PurchaseOrder extends Model
 {
@@ -51,5 +53,82 @@ class PurchaseOrder extends Model
             self::STATUS_ORDERED,
             self::STATUS_PARTIAL,
         ], true);
+    }
+
+    protected function totalQuantityOrdered(): Attribute
+    {
+        return Attribute::make(
+            get: fn (): int => $this->sumItems('quantity_ordered')
+        );
+    }
+
+    protected function totalQuantityReceived(): Attribute
+    {
+        return Attribute::make(
+            get: fn (): int => $this->sumItems('quantity_received')
+        );
+    }
+
+    protected function outstandingQuantity(): Attribute
+    {
+        return Attribute::make(
+            get: fn (): int => max($this->total_quantity_ordered - $this->total_quantity_received, 0)
+        );
+    }
+
+    protected function fulfillmentPercentage(): Attribute
+    {
+        return Attribute::make(
+            get: function (): ?float {
+                $ordered = $this->total_quantity_ordered;
+
+                if ($ordered <= 0) {
+                    return null;
+                }
+
+                return round(min($this->total_quantity_received / $ordered, 1), 4);
+            }
+        );
+    }
+
+    protected function actualLeadTimeDays(): Attribute
+    {
+        return Attribute::make(
+            get: function (): ?float {
+                if ($this->ordered_at === null || $this->received_at === null) {
+                    return null;
+                }
+
+                $seconds = $this->received_at->getTimestamp() - $this->ordered_at->getTimestamp();
+
+                return round($seconds / 86400, 2);
+            }
+        );
+    }
+
+    protected function scheduleVarianceDays(): Attribute
+    {
+        return Attribute::make(
+            get: function (): ?float {
+                if ($this->expected_date === null) {
+                    return null;
+                }
+
+                $expected = $this->expected_date->copy()->endOfDay();
+                $comparison = ($this->received_at ?? Carbon::now())->copy()->endOfDay();
+                $seconds = $comparison->getTimestamp() - $expected->getTimestamp();
+
+                return round($seconds / 86400, 2);
+            }
+        );
+    }
+
+    protected function sumItems(string $column): int
+    {
+        if ($this->relationLoaded('items')) {
+            return (int) $this->items->sum($column);
+        }
+
+        return (int) $this->items()->sum($column);
     }
 }

--- a/app/Services/DashboardMetricsService.php
+++ b/app/Services/DashboardMetricsService.php
@@ -1,0 +1,325 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Product;
+use App\Models\PurchaseOrder;
+use App\Models\Transaction;
+use App\Models\TransactionItem;
+use Carbon\CarbonImmutable;
+
+class DashboardMetricsService
+{
+    public function build(int $days): array
+    {
+        $end = CarbonImmutable::now()->endOfDay();
+        $start = $end->subDays(max(1, $days) - 1)->startOfDay();
+
+        $aggregate = Transaction::query()
+            ->withinPeriod($start, $end)
+            ->selectRaw('SUM(total) as revenue')
+            ->selectRaw('SUM(subtotal) as subtotal')
+            ->selectRaw('SUM(tax_total) as tax_total')
+            ->selectRaw('SUM(discount_total) as discount_total')
+            ->selectRaw('COUNT(*) as transactions')
+            ->selectRaw('SUM(items_count) as items')
+            ->selectRaw('SUM(CASE WHEN tax_total > 0 THEN 1 ELSE 0 END) as taxed_transactions')
+            ->first();
+
+        $revenue = (float) ($aggregate?->revenue ?? 0);
+        $transactions = (int) ($aggregate?->transactions ?? 0);
+        $items = (int) ($aggregate?->items ?? 0);
+        $subtotal = (float) ($aggregate?->subtotal ?? 0);
+        $taxTotal = (float) ($aggregate?->tax_total ?? 0);
+        $discountTotal = (float) ($aggregate?->discount_total ?? 0);
+        $taxedTransactions = (int) ($aggregate?->taxed_transactions ?? 0);
+
+        $averageBasket = $transactions > 0 ? round($items / $transactions, 2) : 0.0;
+
+        $itemCostAggregate = TransactionItem::query()
+            ->whereHas('transaction', static function ($query) use ($start, $end): void {
+                $query->withinPeriod($start, $end);
+            })
+            ->selectRaw('COALESCE(SUM(line_cost), 0) as cost')
+            ->first();
+
+        $totalCost = (float) ($itemCostAggregate?->cost ?? 0.0);
+        $grossProfit = round($revenue - $totalCost, 2);
+        $grossMargin = $revenue > 0 ? round($grossProfit / $revenue, 4) : 0.0;
+
+        $itemCostsSubquery = TransactionItem::query()
+            ->selectRaw('transaction_id, COALESCE(SUM(line_cost), 0) as total_cost')
+            ->groupBy('transaction_id');
+
+        $dailySales = Transaction::query()
+            ->withinPeriod($start, $end)
+            ->leftJoinSub($itemCostsSubquery, 'item_costs', 'transactions.id', '=', 'item_costs.transaction_id')
+            ->selectRaw('DATE(transactions.created_at) as date')
+            ->selectRaw('SUM(transactions.total) as revenue')
+            ->selectRaw('COUNT(*) as transactions')
+            ->selectRaw('SUM(transactions.items_count) as items')
+            ->selectRaw('COALESCE(SUM(item_costs.total_cost), 0) as cost')
+            ->groupByRaw('DATE(transactions.created_at)')
+            ->orderBy('date')
+            ->get()
+            ->map(static function ($row) {
+                $transactions = (int) $row->transactions;
+                $items = (int) $row->items;
+                $revenue = (float) $row->revenue;
+                $cost = (float) $row->cost;
+                $profit = round($revenue - $cost, 2);
+
+                return [
+                    'date' => $row->date,
+                    'revenue' => $revenue,
+                    'transactions' => $transactions,
+                    'items' => $items,
+                    'cost' => $cost,
+                    'profit' => $profit,
+                    'averageBasketSize' => $transactions > 0
+                        ? round($items / $transactions, 2)
+                        : 0.0,
+                ];
+            })
+            ->values()
+            ->all();
+
+        $topSelling = TransactionItem::query()
+            ->whereHas('transaction', static function ($query) use ($start, $end): void {
+                $query->withinPeriod($start, $end);
+            })
+            ->topSelling()
+            ->get()
+            ->map(static function ($row) {
+                $revenue = (float) $row->revenue;
+                $cost = (float) $row->cost;
+                $profit = round($revenue - $cost, 2);
+                $margin = $revenue > 0 ? round($profit / $revenue, 4) : 0.0;
+
+                return [
+                    'name' => $row->name,
+                    'quantity' => (int) $row->quantity,
+                    'revenue' => $revenue,
+                    'cost' => $cost,
+                    'profit' => $profit,
+                    'profitMargin' => $margin,
+                ];
+            })
+            ->values()
+            ->all();
+
+        $defaultReorderPoint = (int) config('store.inventory.low_stock_threshold', 10);
+
+        $lowStockQuery = Product::query()->belowReorderPoint($defaultReorderPoint);
+        $lowStockCount = (clone $lowStockQuery)->count();
+
+        $lowStockProducts = (clone $lowStockQuery)
+            ->select(['id', 'name', 'stock', 'reorder_point', 'reorder_quantity'])
+            ->orderBy('stock')
+            ->orderBy('name')
+            ->limit(5)
+            ->get()
+            ->map(static function (Product $product) use ($defaultReorderPoint) {
+                return [
+                    'id' => $product->id,
+                    'name' => $product->name,
+                    'stock' => $product->stock,
+                    'reorderPoint' => $product->reorder_point,
+                    'effectiveReorderPoint' => $product->effectiveReorderPoint($defaultReorderPoint),
+                    'reorderQuantity' => $product->reorder_quantity,
+                ];
+            })
+            ->values()
+            ->all();
+
+        $customReorderCount = Product::query()->whereNotNull('reorder_point')->count();
+
+        $averageDailyRevenue = $days > 0 ? round($revenue / $days, 2) : 0.0;
+        $averageDailyProfit = $days > 0 ? round($grossProfit / $days, 2) : 0.0;
+        $averageDailyTax = $days > 0 ? round($taxTotal / $days, 2) : 0.0;
+
+        $supplierMetrics = $this->buildSupplierMetrics($start, $end);
+
+        return [
+            'totals' => [
+                'revenue' => $revenue,
+                'transactions' => $transactions,
+                'itemsSold' => $items,
+                'averageBasketSize' => $averageBasket,
+                'lowStockCount' => $lowStockCount,
+                'totalCost' => $totalCost,
+                'grossProfit' => $grossProfit,
+                'grossMargin' => $grossMargin,
+                'taxCollected' => $taxTotal,
+            ],
+            'dailySales' => $dailySales,
+            'topSelling' => $topSelling,
+            'lowStockThreshold' => $defaultReorderPoint,
+            'customReorderCount' => $customReorderCount,
+            'lowStockProducts' => $lowStockProducts,
+            'taxSummary' => [
+                'taxableSales' => $subtotal,
+                'taxCollected' => $taxTotal,
+                'discounts' => $discountTotal,
+                'effectiveTaxRate' => $subtotal > 0 ? round($taxTotal / $subtotal, 4) : 0.0,
+                'transactionsWithTax' => $taxedTransactions,
+                'averageTaxPerTransaction' => $transactions > 0
+                    ? round($taxTotal / $transactions, 2)
+                    : 0.0,
+            ],
+            'forecast' => [
+                'daysEvaluated' => $days,
+                'averageDailyRevenue' => $averageDailyRevenue,
+                'averageDailyProfit' => $averageDailyProfit,
+                'averageDailyTax' => $averageDailyTax,
+                'projectedRevenue30' => round($averageDailyRevenue * 30, 2),
+                'projectedProfit30' => round($averageDailyProfit * 30, 2),
+                'projectedTax30' => round($averageDailyTax * 30, 2),
+            ],
+            'currency' => config('app.currency', 'IDR'),
+            'lastUpdated' => CarbonImmutable::now()->toIso8601String(),
+            'range' => [
+                'start' => $start->toDateString(),
+                'end' => $end->toDateString(),
+                'days' => $days,
+            ],
+            'suppliers' => $supplierMetrics,
+        ];
+    }
+
+    protected function buildSupplierMetrics(CarbonImmutable $start, CarbonImmutable $end): array
+    {
+        $purchaseOrders = PurchaseOrder::query()
+            ->with(['supplier', 'items'])
+            ->whereBetween('created_at', [$start, $end])
+            ->get();
+
+        $completedOrders = $purchaseOrders->filter(static fn (PurchaseOrder $order) => $order->received_at !== null);
+        $onTimeOrders = $completedOrders->filter(static function (PurchaseOrder $order) {
+            $variance = $order->schedule_variance_days;
+
+            return $variance !== null && $variance <= 0;
+        });
+
+        $totalOrdered = $purchaseOrders->sum(static fn (PurchaseOrder $order) => $order->total_quantity_ordered);
+        $totalReceived = $purchaseOrders->sum(static fn (PurchaseOrder $order) => $order->total_quantity_received);
+
+        $allLateDeliveries = $purchaseOrders
+            ->filter(static fn (PurchaseOrder $order) => ($order->schedule_variance_days ?? 0) > 0)
+            ->values();
+
+        $lateDeliveries = $allLateDeliveries
+            ->sortByDesc(static fn (PurchaseOrder $order) => $order->schedule_variance_days ?? 0)
+            ->take(5)
+            ->values()
+            ->map(static function (PurchaseOrder $order) {
+                return [
+                    'id' => $order->id,
+                    'reference' => $order->reference,
+                    'supplierName' => $order->supplier?->name,
+                    'expectedDate' => $order->expected_date?->toDateString(),
+                    'receivedAt' => $order->received_at?->toDateTimeString(),
+                    'varianceDays' => $order->schedule_variance_days,
+                    'fulfillmentRate' => $order->fulfillment_percentage,
+                ];
+            })
+            ->all();
+
+        $allOutstandingOrders = $purchaseOrders
+            ->filter(static fn (PurchaseOrder $order) => $order->outstanding_quantity > 0)
+            ->values();
+
+        $outstandingOrders = $allOutstandingOrders
+            ->sortByDesc(static fn (PurchaseOrder $order) => $order->outstanding_quantity)
+            ->take(5)
+            ->values()
+            ->map(static function (PurchaseOrder $order) {
+                return [
+                    'id' => $order->id,
+                    'reference' => $order->reference,
+                    'supplierName' => $order->supplier?->name,
+                    'expectedDate' => $order->expected_date?->toDateString(),
+                    'outstandingQuantity' => $order->outstanding_quantity,
+                    'fulfillmentRate' => $order->fulfillment_percentage,
+                    'status' => $order->status,
+                ];
+            })
+            ->all();
+
+        $supplierGroups = $purchaseOrders
+            ->filter(static fn (PurchaseOrder $order) => $order->supplier !== null)
+            ->groupBy(static fn (PurchaseOrder $order) => $order->supplier_id);
+
+        $supplierPerformances = $supplierGroups
+            ->map(static function ($orders) {
+                /** @var \Illuminate\Support\Collection<int, PurchaseOrder> $orders */
+                $orders = $orders->values();
+                $supplier = $orders->first()->supplier;
+
+                $totalOrders = $orders->count();
+                $completed = $orders->filter(static fn (PurchaseOrder $order) => $order->received_at !== null);
+                $completedCount = $completed->count();
+                $onTimeCount = $completed->filter(static function (PurchaseOrder $order) {
+                    $variance = $order->schedule_variance_days;
+
+                    return $variance !== null && $variance <= 0;
+                })->count();
+
+                $totalOrdered = $orders->sum(static fn (PurchaseOrder $order) => $order->total_quantity_ordered);
+                $totalReceived = $orders->sum(static fn (PurchaseOrder $order) => $order->total_quantity_received);
+
+                $fulfillmentRate = $totalOrdered > 0 ? round($totalReceived / $totalOrdered, 4) : null;
+                $onTimeRate = $completedCount > 0 ? round($onTimeCount / $completedCount, 4) : null;
+                $averageLeadTime = $completedCount > 0
+                    ? round($completed->avg(static fn (PurchaseOrder $order) => $order->actual_lead_time_days ?? 0), 2)
+                    : null;
+                $averageVariance = $totalOrders > 0
+                    ? round($orders->avg(static fn (PurchaseOrder $order) => $order->schedule_variance_days ?? 0), 2)
+                    : null;
+                $lateDeliveries = $orders
+                    ->filter(static fn (PurchaseOrder $order) => ($order->schedule_variance_days ?? 0) > 0)
+                    ->count();
+                $score = round((($onTimeRate ?? 0) * 0.6) + (($fulfillmentRate ?? 0) * 0.4), 4);
+
+                return [
+                    'supplierId' => $supplier?->id,
+                    'supplierName' => $supplier?->name,
+                    'orders' => $totalOrders,
+                    'completedOrders' => $completedCount,
+                    'onTimeRate' => $onTimeRate,
+                    'averageLeadTime' => $averageLeadTime,
+                    'averageVariance' => $averageVariance,
+                    'fulfillmentRate' => $fulfillmentRate,
+                    'lateDeliveries' => $lateDeliveries,
+                    'score' => $score,
+                ];
+            })
+            ->values();
+
+        $summary = [
+            'suppliersEvaluated' => $supplierGroups->count(),
+            'averageLeadTime' => $completedOrders->count() > 0
+                ? round($completedOrders->avg(static fn (PurchaseOrder $order) => $order->actual_lead_time_days ?? 0), 2)
+                : null,
+            'averageFulfillmentRate' => $totalOrdered > 0
+                ? round($totalReceived / $totalOrdered, 4)
+                : null,
+            'onTimeRate' => $completedOrders->count() > 0
+                ? round($onTimeOrders->count() / $completedOrders->count(), 4)
+                : null,
+            'lateDeliveryCount' => $allLateDeliveries->count(),
+            'outstandingCount' => $allOutstandingOrders->count(),
+        ];
+
+        return [
+            'summary' => $summary,
+            'topSuppliers' => $supplierPerformances
+                ->sortByDesc(static fn (array $performance) => $performance['score'])
+                ->take(5)
+                ->values()
+                ->all(),
+            'lateDeliveries' => $lateDeliveries,
+            'outstandingOrders' => $outstandingOrders,
+        ];
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Console\Commands\CheckLowStockCommand;
+use App\Console\Commands\WarmDashboardMetricsCommand;
 use App\Http\Middleware\HandleAppearance;
 use App\Http\Middleware\HandleInertiaRequests;
 use Illuminate\Foundation\Application;
@@ -12,6 +13,7 @@ use Illuminate\Console\Scheduling\Schedule;
 return Application::configure(basePath: dirname(__DIR__))
     ->withCommands([
         CheckLowStockCommand::class,
+        WarmDashboardMetricsCommand::class,
     ])
     ->withRouting(
         web: __DIR__.'/../routes/web.php',
@@ -29,6 +31,7 @@ return Application::configure(basePath: dirname(__DIR__))
     })
     ->withSchedule(function (Schedule $schedule): void {
         $schedule->command('inventory:check-low-stock')->dailyAt('08:00');
+        $schedule->command('dashboard:warm')->dailyAt('02:00');
     })
     ->withExceptions(function (Exceptions $exceptions) {
         //

--- a/database/factories/ProductFactory.php
+++ b/database/factories/ProductFactory.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Product;
+use App\Models\Supplier;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<Product>
+ */
+class ProductFactory extends Factory
+{
+    protected $model = Product::class;
+
+    public function definition(): array
+    {
+        $cost = $this->faker->randomFloat(2, 1000, 50000);
+
+        return [
+            'supplier_id' => Supplier::factory(),
+            'barcode' => $this->faker->unique()->ean13(),
+            'supplier_sku' => strtoupper(Str::random(8)),
+            'name' => $this->faker->words(3, true),
+            'stock' => $this->faker->numberBetween(0, 50),
+            'price' => $cost + $this->faker->randomFloat(2, 500, 5000),
+            'cost_price' => $cost,
+            'image_path' => null,
+            'reorder_point' => null,
+            'reorder_quantity' => null,
+        ];
+    }
+}

--- a/database/factories/PurchaseOrderFactory.php
+++ b/database/factories/PurchaseOrderFactory.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\PurchaseOrder;
+use App\Models\Supplier;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<PurchaseOrder>
+ */
+class PurchaseOrderFactory extends Factory
+{
+    protected $model = PurchaseOrder::class;
+
+    public function definition(): array
+    {
+        $orderedAt = Carbon::instance($this->faker->dateTimeBetween('-1 month', '-1 week'));
+        $expectedDate = $orderedAt->copy()->addDays($this->faker->numberBetween(3, 14));
+
+        return [
+            'reference' => strtoupper(Str::random(10)),
+            'supplier_id' => Supplier::factory(),
+            'status' => PurchaseOrder::STATUS_ORDERED,
+            'expected_date' => $expectedDate->toDateString(),
+            'ordered_at' => $orderedAt,
+            'received_at' => null,
+            'total_cost' => $this->faker->randomFloat(2, 100000, 500000),
+            'notes' => $this->faker->optional()->sentence(),
+            'created_at' => $orderedAt,
+            'updated_at' => $orderedAt,
+        ];
+    }
+}

--- a/database/factories/PurchaseOrderItemFactory.php
+++ b/database/factories/PurchaseOrderItemFactory.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Product;
+use App\Models\PurchaseOrder;
+use App\Models\PurchaseOrderItem;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<PurchaseOrderItem>
+ */
+class PurchaseOrderItemFactory extends Factory
+{
+    protected $model = PurchaseOrderItem::class;
+
+    public function definition(): array
+    {
+        $quantityOrdered = $this->faker->numberBetween(5, 30);
+        $quantityReceived = $this->faker->numberBetween(0, $quantityOrdered);
+
+        return [
+            'purchase_order_id' => PurchaseOrder::factory(),
+            'product_id' => Product::factory(),
+            'quantity_ordered' => $quantityOrdered,
+            'quantity_received' => $quantityReceived,
+            'unit_cost' => $this->faker->randomFloat(2, 5000, 50000),
+            'notes' => $this->faker->optional()->sentence(),
+        ];
+    }
+}

--- a/database/factories/SupplierFactory.php
+++ b/database/factories/SupplierFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Supplier;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Supplier>
+ */
+class SupplierFactory extends Factory
+{
+    protected $model = Supplier::class;
+
+    public function definition(): array
+    {
+        return [
+            'name' => $this->faker->company(),
+            'contact_name' => $this->faker->name(),
+            'email' => $this->faker->unique()->safeEmail(),
+            'phone' => $this->faker->phoneNumber(),
+            'lead_time_days' => $this->faker->numberBetween(2, 14),
+            'notes' => $this->faker->optional()->sentence(),
+        ];
+    }
+}

--- a/tests/Feature/DashboardTest.php
+++ b/tests/Feature/DashboardTest.php
@@ -1,6 +1,15 @@
 <?php
 
+use App\Models\Product;
+use App\Models\PurchaseOrder;
+use App\Models\PurchaseOrderItem;
+use App\Models\Supplier;
 use App\Models\User;
+use Carbon\CarbonImmutable;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Config;
+use Inertia\Testing\AssertableInertia as Assert;
 
 test('guests are redirected to the login page', function () {
     $this->get(route('dashboard'))->assertRedirect(route('login'));
@@ -10,4 +19,123 @@ test('authenticated users can visit the dashboard', function () {
     $this->actingAs($user = User::factory()->create());
 
     $this->get(route('dashboard'))->assertOk();
+});
+
+test('dashboard metrics include supplier analytics', function () {
+    Config::set('store.dashboard.cache_minutes', 0);
+    Cache::flush();
+    $now = CarbonImmutable::parse('2024-01-15 12:00:00');
+    CarbonImmutable::setTestNow($now);
+    Carbon::setTestNow($now);
+
+    $user = User::factory()->create();
+    $this->actingAs($user);
+
+    $supplierAlpha = Supplier::factory()->create(['name' => 'Alpha Supplies']);
+    $supplierBeta = Supplier::factory()->create(['name' => 'Beta Traders']);
+    $supplierGamma = Supplier::factory()->create(['name' => 'Gamma Goods']);
+
+    $alphaProduct = Product::factory()->for($supplierAlpha, 'supplier')->create(['name' => 'Alpha Widget']);
+    $betaProduct = Product::factory()->for($supplierBeta, 'supplier')->create(['name' => 'Beta Widget']);
+    $gammaProduct = Product::factory()->for($supplierGamma, 'supplier')->create(['name' => 'Gamma Widget']);
+
+    $orderAlphaEarly = PurchaseOrder::factory()
+        ->for($supplierAlpha)
+        ->create([
+            'reference' => 'PO-ALPHA-1',
+            'status' => PurchaseOrder::STATUS_RECEIVED,
+            'ordered_at' => CarbonImmutable::parse('2024-01-01 08:00:00'),
+            'expected_date' => CarbonImmutable::parse('2024-01-10'),
+            'received_at' => CarbonImmutable::parse('2024-01-09 09:00:00'),
+            'created_at' => CarbonImmutable::parse('2024-01-01 08:00:00'),
+            'updated_at' => CarbonImmutable::parse('2024-01-09 09:00:00'),
+        ]);
+
+    PurchaseOrderItem::factory()
+        ->for($orderAlphaEarly, 'purchaseOrder')
+        ->for($alphaProduct, 'product')
+        ->create([
+            'quantity_ordered' => 10,
+            'quantity_received' => 10,
+            'unit_cost' => 12000,
+        ]);
+
+    $orderAlphaLate = PurchaseOrder::factory()
+        ->for($supplierAlpha)
+        ->create([
+            'reference' => 'PO-ALPHA-2',
+            'status' => PurchaseOrder::STATUS_PARTIAL,
+            'ordered_at' => CarbonImmutable::parse('2024-01-03 08:00:00'),
+            'expected_date' => CarbonImmutable::parse('2024-01-12'),
+            'received_at' => CarbonImmutable::parse('2024-01-15 13:00:00'),
+            'created_at' => CarbonImmutable::parse('2024-01-03 08:00:00'),
+            'updated_at' => CarbonImmutable::parse('2024-01-15 13:00:00'),
+        ]);
+
+    PurchaseOrderItem::factory()
+        ->for($orderAlphaLate, 'purchaseOrder')
+        ->for($alphaProduct, 'product')
+        ->create([
+            'quantity_ordered' => 20,
+            'quantity_received' => 18,
+            'unit_cost' => 15000,
+        ]);
+
+    $orderBetaOnTime = PurchaseOrder::factory()
+        ->for($supplierBeta)
+        ->create([
+            'reference' => 'PO-BETA-1',
+            'status' => PurchaseOrder::STATUS_RECEIVED,
+            'ordered_at' => CarbonImmutable::parse('2024-01-06 09:00:00'),
+            'expected_date' => CarbonImmutable::parse('2024-01-08'),
+            'received_at' => CarbonImmutable::parse('2024-01-08 15:00:00'),
+            'created_at' => CarbonImmutable::parse('2024-01-06 09:00:00'),
+            'updated_at' => CarbonImmutable::parse('2024-01-08 15:00:00'),
+        ]);
+
+    PurchaseOrderItem::factory()
+        ->for($orderBetaOnTime, 'purchaseOrder')
+        ->for($betaProduct, 'product')
+        ->create([
+            'quantity_ordered' => 12,
+            'quantity_received' => 12,
+            'unit_cost' => 11000,
+        ]);
+
+    $orderGammaOutstanding = PurchaseOrder::factory()
+        ->for($supplierGamma)
+        ->create([
+            'reference' => 'PO-GAMMA-1',
+            'status' => PurchaseOrder::STATUS_ORDERED,
+            'ordered_at' => CarbonImmutable::parse('2024-01-05 10:00:00'),
+            'expected_date' => CarbonImmutable::parse('2024-01-11'),
+            'received_at' => null,
+            'created_at' => CarbonImmutable::parse('2024-01-05 10:00:00'),
+            'updated_at' => CarbonImmutable::parse('2024-01-05 10:00:00'),
+        ]);
+
+    PurchaseOrderItem::factory()
+        ->for($orderGammaOutstanding, 'purchaseOrder')
+        ->for($gammaProduct, 'product')
+        ->create([
+            'quantity_ordered' => 15,
+            'quantity_received' => 0,
+            'unit_cost' => 9000,
+        ]);
+
+    $response = $this->get(route('dashboard', ['days' => 14]));
+
+    $response->assertInertia(function (Assert $page) {
+        $page->component('dashboard')
+            ->where('metrics.suppliers.summary.suppliersEvaluated', 3)
+            ->where('metrics.suppliers.summary.lateDeliveryCount', 1)
+            ->where('metrics.suppliers.summary.outstandingCount', 2)
+            ->where('metrics.suppliers.topSuppliers.0.supplierName', 'Beta Traders')
+            ->where('metrics.suppliers.topSuppliers.1.supplierName', 'Alpha Supplies')
+            ->where('metrics.suppliers.lateDeliveries.0.reference', 'PO-ALPHA-2')
+            ->where('metrics.suppliers.outstandingOrders.0.reference', 'PO-GAMMA-1');
+    });
+
+    CarbonImmutable::setTestNow();
+    Carbon::setTestNow();
 });


### PR DESCRIPTION
## Summary
- extract dashboard metric aggregation into a reusable DashboardMetricsService and add a nightly cache warming command
- extend purchase orders with lead time, fulfillment, and variance helpers and surface new supplier KPIs from the dashboard controller
- enhance the dashboard UI with supplier performance widgets and add factories plus feature coverage for the new analytics
