### PR TITLE
Add configurable store branding across POS surfaces

### DIFF
--- a/app/Http/Controllers/Settings/StoreSettingsController.php
+++ b/app/Http/Controllers/Settings/StoreSettingsController.php
@@ -7,6 +7,7 @@ use App\Http\Requests\Settings\UpdateStoreSettingsRequest;
 use App\Models\StoreSetting;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Redirect;
+use Illuminate\Support\Facades\Storage;
 use Inertia\Inertia;
 use Inertia\Response;
 
@@ -19,6 +20,12 @@ class StoreSettingsController extends Controller
         return Inertia::render('settings/store', [
             'settings' => [
                 'ppn_rate' => (float) $settings->ppn_rate,
+                'store_name' => $settings->store_name ?? '',
+                'contact_details' => $settings->contact_details,
+                'receipt_footer_text' => $settings->receipt_footer_text,
+                'logo_url' => $settings->logo_path
+                    ? Storage::disk('public')->url($settings->logo_path)
+                    : null,
                 'updated_at' => $settings->updated_at?->toIso8601String(),
             ],
         ]);
@@ -27,9 +34,35 @@ class StoreSettingsController extends Controller
     public function update(UpdateStoreSettingsRequest $request): RedirectResponse
     {
         $settings = StoreSetting::current();
-        $settings->update([
+        $storeName = $request->string('store_name')->trim()->toString();
+        $contactDetails = $request->filled('contact_details')
+            ? (string) $request->input('contact_details')
+            : null;
+        $receiptFooter = $request->filled('receipt_footer_text')
+            ? (string) $request->input('receipt_footer_text')
+            : null;
+
+        $payload = [
             'ppn_rate' => $request->float('ppn_rate'),
-        ]);
+            'store_name' => $storeName,
+            'contact_details' => $contactDetails,
+            'receipt_footer_text' => $receiptFooter,
+        ];
+
+        if ($request->boolean('remove_logo') && $settings->logo_path) {
+            Storage::disk('public')->delete($settings->logo_path);
+            $payload['logo_path'] = null;
+        }
+
+        if ($request->hasFile('logo')) {
+            if ($settings->logo_path) {
+                Storage::disk('public')->delete($settings->logo_path);
+            }
+
+            $payload['logo_path'] = $request->file('logo')->store('branding', 'public');
+        }
+
+        $settings->update($payload);
 
         return Redirect::back()->with('success', 'Store settings updated successfully.');
     }

--- a/app/Http/Requests/Settings/UpdateStoreSettingsRequest.php
+++ b/app/Http/Requests/Settings/UpdateStoreSettingsRequest.php
@@ -23,6 +23,11 @@ class UpdateStoreSettingsRequest extends FormRequest
     {
         return [
             'ppn_rate' => ['required', 'numeric', 'between:0,100'],
+            'store_name' => ['required', 'string', 'max:255'],
+            'contact_details' => ['nullable', 'string', 'max:1000'],
+            'receipt_footer_text' => ['nullable', 'string', 'max:1000'],
+            'logo' => ['nullable', 'image', 'max:2048'],
+            'remove_logo' => ['sometimes', 'boolean'],
         ];
     }
 }

--- a/app/Models/StoreSetting.php
+++ b/app/Models/StoreSetting.php
@@ -16,6 +16,10 @@ class StoreSetting extends Model
      */
     protected $fillable = [
         'ppn_rate',
+        'store_name',
+        'contact_details',
+        'logo_path',
+        'receipt_footer_text',
     ];
 
     /**
@@ -31,6 +35,10 @@ class StoreSetting extends Model
     {
         return static::query()->first() ?? static::query()->create([
             'ppn_rate' => 11.0,
+            'store_name' => 'Retail Store',
+            'contact_details' => null,
+            'logo_path' => null,
+            'receipt_footer_text' => null,
         ]);
     }
 }

--- a/app/Services/DashboardMetricsService.php
+++ b/app/Services/DashboardMetricsService.php
@@ -208,7 +208,11 @@ class DashboardMetricsService
             ->filter(static fn (PurchaseOrder $order) => ($order->schedule_variance_days ?? 0) > 0)
             ->values();
 
-        $lateDeliveries = $allLateDeliveries
+        $lateCompletedDeliveries = $completedOrders
+            ->filter(static fn (PurchaseOrder $order) => ($order->schedule_variance_days ?? 0) > 0)
+            ->values();
+
+        $lateDeliveries = $lateCompletedDeliveries
             ->sortByDesc(static fn (PurchaseOrder $order) => $order->schedule_variance_days ?? 0)
             ->take(5)
             ->values()
@@ -307,7 +311,7 @@ class DashboardMetricsService
             'onTimeRate' => $completedOrders->count() > 0
                 ? round($onTimeOrders->count() / $completedOrders->count(), 4)
                 : null,
-            'lateDeliveryCount' => $allLateDeliveries->count(),
+            'lateDeliveryCount' => $lateCompletedDeliveries->count(),
             'outstandingCount' => $allOutstandingOrders->count(),
         ];
 

--- a/database/migrations/2025_10_20_000200_add_branding_fields_to_store_settings_table.php
+++ b/database/migrations/2025_10_20_000200_add_branding_fields_to_store_settings_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('store_settings', function (Blueprint $table): void {
+            $table->string('store_name')->nullable()->after('ppn_rate');
+            $table->text('contact_details')->nullable()->after('store_name');
+            $table->string('logo_path')->nullable()->after('contact_details');
+            $table->text('receipt_footer_text')->nullable()->after('logo_path');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('store_settings', function (Blueprint $table): void {
+            $table->dropColumn([
+                'store_name',
+                'contact_details',
+                'logo_path',
+                'receipt_footer_text',
+            ]);
+        });
+    }
+};

--- a/resources/js/pages/settings/store.tsx
+++ b/resources/js/pages/settings/store.tsx
@@ -2,28 +2,63 @@ import InputError from '@/components/input-error';
 import SettingsLayout from '@/layouts/settings/layout';
 import { type SharedData } from '@/types';
 import { Head, useForm, usePage } from '@inertiajs/react';
-import { FormEvent } from 'react';
+import { ChangeEvent, FormEvent } from 'react';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { Checkbox } from '@/components/ui/checkbox';
 
 interface StoreSettingsPageProps {
     settings: {
         ppn_rate: number;
+        store_name: string;
+        contact_details?: string | null;
+        receipt_footer_text?: string | null;
+        logo_url?: string | null;
         updated_at?: string | null;
     };
 }
 
 export default function StoreSettings({ settings }: StoreSettingsPageProps) {
     const { flash } = usePage<SharedData>().props;
-    const form = useForm<{ ppn_rate: string }>({
+    const form = useForm<{
+        ppn_rate: string;
+        store_name: string;
+        contact_details: string;
+        receipt_footer_text: string;
+        logo: File | null;
+        remove_logo: boolean;
+    }>({
         ppn_rate: settings.ppn_rate.toString(),
+        store_name: settings.store_name,
+        contact_details: settings.contact_details ?? '',
+        receipt_footer_text: settings.receipt_footer_text ?? '',
+        logo: null,
+        remove_logo: false,
     });
 
     const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
         event.preventDefault();
-        form.put('/settings/store');
+        form.post('/settings/store', {
+            method: 'put',
+            forceFormData: true,
+        });
+    };
+
+    const handleLogoChange = (event: ChangeEvent<HTMLInputElement>) => {
+        form.setData('logo', event.target.files?.[0] ?? null);
+        if (event.target.files?.[0]) {
+            form.setData('remove_logo', false);
+        }
+    };
+
+    const handleRemoveLogoChange = (checked: boolean | 'indeterminate') => {
+        const value = checked === true;
+        form.setData('remove_logo', value);
+        if (value) {
+            form.setData('logo', null);
+        }
     };
 
     return (
@@ -31,10 +66,11 @@ export default function StoreSettings({ settings }: StoreSettingsPageProps) {
             <Head title="Store settings" />
 
             <div className="space-y-6">
-                <div>
+                <div className="space-y-1">
                     <h2 className="text-lg font-semibold">Store preferences</h2>
                     <p className="text-sm text-muted-foreground">
-                        Configure tax settings that are used when recording transactions.
+                        Configure branding and tax settings that are used across the point of sale
+                        experience.
                     </p>
                 </div>
 
@@ -45,20 +81,108 @@ export default function StoreSettings({ settings }: StoreSettingsPageProps) {
                     </Alert>
                 )}
 
-                <form className="space-y-4" onSubmit={handleSubmit}>
-                    <div className="space-y-2">
-                        <Label htmlFor="ppn_rate">PPN rate (%)</Label>
-                        <Input
-                            id="ppn_rate"
-                            name="ppn_rate"
-                            type="number"
-                            min={0}
-                            max={100}
-                            step="0.01"
-                            value={form.data.ppn_rate}
-                            onChange={(event) => form.setData('ppn_rate', event.target.value)}
-                        />
-                        <InputError message={form.errors.ppn_rate} />
+                <form className="space-y-6" onSubmit={handleSubmit}>
+                    <div className="grid gap-4 md:grid-cols-2">
+                        <div className="space-y-2">
+                            <Label htmlFor="store_name">Store name</Label>
+                            <Input
+                                id="store_name"
+                                name="store_name"
+                                value={form.data.store_name}
+                                onChange={(event) => form.setData('store_name', event.target.value)}
+                            />
+                            <InputError message={form.errors.store_name} />
+                        </div>
+
+                        <div className="space-y-2">
+                            <Label htmlFor="ppn_rate">PPN rate (%)</Label>
+                            <Input
+                                id="ppn_rate"
+                                name="ppn_rate"
+                                type="number"
+                                min={0}
+                                max={100}
+                                step="0.01"
+                                value={form.data.ppn_rate}
+                                onChange={(event) => form.setData('ppn_rate', event.target.value)}
+                            />
+                            <InputError message={form.errors.ppn_rate} />
+                        </div>
+                    </div>
+
+                    <div className="grid gap-4 md:grid-cols-2">
+                        <div className="space-y-2">
+                            <Label htmlFor="contact_details">Contact details</Label>
+                            <textarea
+                                id="contact_details"
+                                name="contact_details"
+                                value={form.data.contact_details}
+                                onChange={(event) =>
+                                    form.setData('contact_details', event.target.value)
+                                }
+                                className="min-h-[96px] w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-xs transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 focus-visible:ring-offset-2"
+                            />
+                            <InputError message={form.errors.contact_details} />
+                        </div>
+
+                        <div className="space-y-2">
+                            <Label htmlFor="receipt_footer_text">Receipt footer</Label>
+                            <textarea
+                                id="receipt_footer_text"
+                                name="receipt_footer_text"
+                                value={form.data.receipt_footer_text}
+                                onChange={(event) =>
+                                    form.setData('receipt_footer_text', event.target.value)
+                                }
+                                className="min-h-[96px] w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-xs transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 focus-visible:ring-offset-2"
+                            />
+                            <InputError message={form.errors.receipt_footer_text} />
+                        </div>
+                    </div>
+
+                    <div className="space-y-3">
+                        <div className="space-y-2">
+                            <Label htmlFor="logo">Logo</Label>
+                            <Input
+                                id="logo"
+                                name="logo"
+                                type="file"
+                                accept="image/*"
+                                onChange={handleLogoChange}
+                            />
+                            <InputError message={form.errors.logo} />
+                        </div>
+
+                        {(settings.logo_url || form.data.remove_logo) && (
+                            <div className="flex items-start gap-3">
+                                <Checkbox
+                                    id="remove_logo"
+                                    checked={form.data.remove_logo}
+                                    onCheckedChange={handleRemoveLogoChange}
+                                />
+                                <div className="space-y-1 text-sm">
+                                    <Label htmlFor="remove_logo" className="font-medium">
+                                        Remove existing logo
+                                    </Label>
+                                    <p className="text-muted-foreground">
+                                        Enable this option to clear the current store logo.
+                                    </p>
+                                </div>
+                            </div>
+                        )}
+
+                        {settings.logo_url && !form.data.remove_logo && (
+                            <div className="rounded-md border border-dashed border-border p-4">
+                                <p className="mb-2 text-sm font-medium text-muted-foreground">
+                                    Current logo preview
+                                </p>
+                                <img
+                                    src={settings.logo_url}
+                                    alt={`${settings.store_name} logo`}
+                                    className="h-20 w-auto"
+                                />
+                            </div>
+                        )}
                     </div>
 
                     <div className="flex items-center justify-end gap-2">

--- a/resources/js/pages/transactions/customer.tsx
+++ b/resources/js/pages/transactions/customer.tsx
@@ -38,10 +38,18 @@ interface TransactionSummary {
     items: TransactionItemSummary[];
 }
 
+interface BrandingInfo {
+    store_name: string | null;
+    contact_details: string | null;
+    receipt_footer_text: string | null;
+    logo_url: string | null;
+}
+
 interface CustomerDisplayProps {
     transaction: TransactionSummary | null;
     autoRefresh: boolean;
     latestUrl: string;
+    branding: BrandingInfo;
 }
 
 const formatCurrency = (value: number) =>
@@ -62,7 +70,12 @@ const formatDate = (value: string | null) => {
     }).format(new Date(value));
 };
 
-export default function CustomerDisplay({ transaction, autoRefresh, latestUrl }: CustomerDisplayProps) {
+export default function CustomerDisplay({
+    transaction,
+    autoRefresh,
+    latestUrl,
+    branding,
+}: CustomerDisplayProps) {
     const [shouldAutoPrint, setShouldAutoPrint] = useState(false);
     const hasPrintedRef = useRef(false);
 
@@ -121,11 +134,32 @@ export default function CustomerDisplay({ transaction, autoRefresh, latestUrl }:
             <Head title="Customer display" />
 
             <div className="space-y-6">
-                <header className="space-y-1 text-center">
-                    <h1 className="text-4xl font-bold tracking-tight">Terima kasih telah berbelanja</h1>
-                    <p className="text-lg text-muted-foreground">
-                        Harap pastikan semua item sudah sesuai sebelum melakukan pembayaran.
-                    </p>
+                <header className="space-y-3 text-center">
+                    {branding.logo_url && (
+                        <div className="flex justify-center">
+                            <img
+                                src={branding.logo_url}
+                                alt={`${branding.store_name ?? 'Store'} logo`}
+                                className="h-24 w-auto rounded-md border border-border bg-white p-3 shadow-sm"
+                            />
+                        </div>
+                    )}
+                    <h1 className="text-4xl font-bold tracking-tight">
+                        {branding.store_name ?? 'Terima kasih telah berbelanja'}
+                    </h1>
+                    <div className="space-y-1 text-lg text-muted-foreground">
+                        {branding.store_name && (
+                            <p>Terima kasih telah berbelanja bersama kami.</p>
+                        )}
+                        {branding.contact_details && (
+                            <p className="whitespace-pre-line text-base text-muted-foreground">
+                                {branding.contact_details}
+                            </p>
+                        )}
+                        <p className="text-base text-muted-foreground">
+                            Harap pastikan semua item sudah sesuai sebelum melakukan pembayaran.
+                        </p>
+                    </div>
                 </header>
 
                 {autoRefresh && (
@@ -143,9 +177,7 @@ export default function CustomerDisplay({ transaction, autoRefresh, latestUrl }:
                             <>
                                 <div>
                                     Nomor transaksi:{' '}
-                                    <span className="font-semibold text-foreground">
-                                        {transaction.number}
-                                    </span>
+                                    <span className="font-semibold text-foreground">{transaction.number}</span>
                                 </div>
                                 <div>Waktu: {formatDate(transaction.created_at)}</div>
                                 {transaction.user && <div>Kasir: {transaction.user.name}</div>}
@@ -269,6 +301,18 @@ export default function CustomerDisplay({ transaction, autoRefresh, latestUrl }:
                         </p>
                     </div>
                 )}
+
+                <footer className="rounded-xl border border-dashed border-border bg-background/70 p-6 text-center text-base text-muted-foreground">
+                    {branding.receipt_footer_text ? (
+                        <p className="whitespace-pre-line text-sm text-muted-foreground">
+                            {branding.receipt_footer_text}
+                        </p>
+                    ) : (
+                        <p className="text-sm text-muted-foreground">
+                            Simpan struk ini sebagai bukti pembayaran dan hubungi kasir bila ada pertanyaan.
+                        </p>
+                    )}
+                </footer>
             </div>
         </CustomerLayout>
     );

--- a/resources/js/pages/transactions/employee.tsx
+++ b/resources/js/pages/transactions/employee.tsx
@@ -30,6 +30,13 @@ interface CustomerSummary {
     enrolled_at?: string | null;
 }
 
+interface BrandingInfo {
+    store_name: string | null;
+    contact_details: string | null;
+    receipt_footer_text: string | null;
+    logo_url: string | null;
+}
+
 interface EmployeeTransactionsPageProps {
     ppnRate: number;
     productLookupUrl: string;
@@ -39,6 +46,7 @@ interface EmployeeTransactionsPageProps {
     customerLatestUrl: string;
     customerSearchUrl: string;
     customerStoreUrl: string;
+    branding: BrandingInfo;
 }
 
 interface CartItem extends TransactionProduct {
@@ -79,6 +87,7 @@ export default function EmployeeTransactions({
     customerLatestUrl,
     customerSearchUrl,
     customerStoreUrl,
+    branding,
 }: EmployeeTransactionsPageProps) {
     const { flash } = usePage<SharedData>().props;
     const [items, setItems] = useState<CartItem[]>([]);
@@ -678,15 +687,34 @@ export default function EmployeeTransactions({
             <Head title="Point of Sale" />
 
             <div className="space-y-6 p-4">
-                <div className="flex items-start justify-between gap-4">
-                    <div>
-                        <h1 className="text-2xl font-semibold">Employee POS</h1>
-                        <p className="text-sm text-muted-foreground">
-                            Scan product barcodes or search manually to build a transaction.
-                        </p>
-                        <p className="mt-2 text-sm text-muted-foreground">
-                            Current PPN rate: <span className="font-medium">{ppnRate}%</span>
-                        </p>
+                <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+                    <div className="flex flex-1 items-start gap-4">
+                        {branding.logo_url && (
+                            <img
+                                src={branding.logo_url}
+                                alt={`${branding.store_name ?? 'Store'} logo`}
+                                className="h-16 w-auto rounded-md border border-border bg-white p-2 shadow-sm"
+                            />
+                        )}
+                        <div className="space-y-3">
+                            <div className="space-y-1">
+                                <h1 className="text-2xl font-semibold">
+                                    {branding.store_name ?? 'Employee POS'}
+                                </h1>
+                                {branding.contact_details && (
+                                    <p className="whitespace-pre-line text-sm text-muted-foreground">
+                                        {branding.contact_details}
+                                    </p>
+                                )}
+                            </div>
+                            <div className="space-y-1 text-sm text-muted-foreground">
+                                <p>Scan product barcodes or search manually to build a transaction.</p>
+                                <p>
+                                    Current PPN rate:{' '}
+                                    <span className="font-medium text-foreground">{ppnRate}%</span>
+                                </p>
+                            </div>
+                        </div>
                     </div>
                     <div className="flex flex-col items-end gap-2 text-right text-sm">
                         <Button

--- a/tests/Feature/Settings/StoreSettingsTest.php
+++ b/tests/Feature/Settings/StoreSettingsTest.php
@@ -1,0 +1,91 @@
+<?php
+
+use App\Models\StoreSetting;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Spatie\Permission\Models\Permission;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function (): void {
+    $this->withoutVite();
+});
+
+function createManagerUser(): User
+{
+    $user = User::factory()->create();
+    $permission = Permission::query()->firstOrCreate([
+        'name' => 'manage settings',
+        'guard_name' => 'web',
+    ]);
+
+    $user->givePermissionTo($permission);
+
+    return $user;
+}
+
+test('store managers can update branding settings with a logo', function () {
+    Storage::fake('public');
+
+    $user = createManagerUser();
+    $logo = UploadedFile::fake()->image('logo.png', 200, 200);
+
+    $response = $this
+        ->actingAs($user)
+        ->from(route('store.edit'))
+        ->put(route('store.update'), [
+            'ppn_rate' => 12.5,
+            'store_name' => 'Sunrise Mart',
+            'contact_details' => "Jl. Contoh No. 1\nJakarta",
+            'receipt_footer_text' => 'Terima kasih atas kunjungan Anda',
+            'logo' => $logo,
+        ]);
+
+    $response->assertRedirect(route('store.edit'))
+        ->assertSessionHas('success');
+
+    $settings = StoreSetting::current()->fresh();
+
+    expect((float) $settings->ppn_rate)->toBe(12.5)
+        ->and($settings->store_name)->toBe('Sunrise Mart')
+        ->and($settings->contact_details)->toBe("Jl. Contoh No. 1\nJakarta")
+        ->and($settings->receipt_footer_text)->toBe('Terima kasih atas kunjungan Anda')
+        ->and($settings->logo_path)->not()->toBeNull();
+
+    Storage::disk('public')->assertExists($settings->logo_path);
+});
+
+test('store logo can be removed without uploading a replacement', function () {
+    Storage::fake('public');
+
+    $settings = StoreSetting::current();
+    $settings->update([
+        'store_name' => 'Sunrise Mart',
+        'logo_path' => 'branding/logo.png',
+    ]);
+
+    Storage::disk('public')->put('branding/logo.png', 'logo');
+
+    $user = createManagerUser();
+
+    $response = $this
+        ->actingAs($user)
+        ->from(route('store.edit'))
+        ->put(route('store.update'), [
+            'ppn_rate' => 10,
+            'store_name' => 'Sunrise Mart',
+            'contact_details' => null,
+            'receipt_footer_text' => null,
+            'remove_logo' => true,
+        ]);
+
+    $response->assertRedirect(route('store.edit'))
+        ->assertSessionHas('success');
+
+    $settings->refresh();
+
+    expect($settings->logo_path)->toBeNull();
+    Storage::disk('public')->assertMissing('branding/logo.png');
+});

--- a/tests/Feature/Transactions/TransactionBrandingTest.php
+++ b/tests/Feature/Transactions/TransactionBrandingTest.php
@@ -1,0 +1,99 @@
+<?php
+
+use App\Models\StoreSetting;
+use App\Models\Transaction;
+use App\Models\TransactionItem;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Storage;
+use Inertia\Testing\AssertableInertia as Assert;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function (): void {
+    $this->withoutVite();
+});
+
+test('employee transaction page includes branding data', function () {
+    Storage::fake('public');
+
+    $settings = StoreSetting::current();
+    $settings->update([
+        'store_name' => 'Sunrise Mart',
+        'contact_details' => 'Jl. Contoh No. 1, Jakarta',
+        'receipt_footer_text' => 'Terima kasih dan sampai jumpa kembali.',
+        'logo_path' => 'branding/logo.png',
+    ]);
+
+    Storage::disk('public')->put('branding/logo.png', 'logo');
+
+    $user = User::factory()->create();
+
+    $response = $this->actingAs($user)->get(route('transactions.employee'));
+
+    $logoUrl = Storage::disk('public')->url('branding/logo.png');
+
+    $response->assertInertia(fn (Assert $page) => $page
+        ->component('transactions/employee')
+        ->where('branding.store_name', 'Sunrise Mart')
+        ->where('branding.contact_details', 'Jl. Contoh No. 1, Jakarta')
+        ->where('branding.receipt_footer_text', 'Terima kasih dan sampai jumpa kembali.')
+        ->where('branding.logo_url', $logoUrl)
+    );
+});
+
+test('customer transaction view serializes branding data', function () {
+    Storage::fake('public');
+
+    $settings = StoreSetting::current();
+    $settings->update([
+        'store_name' => 'Sunrise Mart',
+        'contact_details' => 'Jl. Contoh No. 1, Jakarta',
+        'receipt_footer_text' => 'Terima kasih dan sampai jumpa kembali.',
+        'logo_path' => 'branding/logo.png',
+    ]);
+
+    Storage::disk('public')->put('branding/logo.png', 'logo');
+
+    $user = User::factory()->create();
+
+    $transaction = Transaction::query()->create([
+        'number' => 'TRX-1001',
+        'user_id' => $user->id,
+        'customer_id' => null,
+        'items_count' => 1,
+        'ppn_rate' => $settings->ppn_rate,
+        'subtotal' => 100_000,
+        'tax_total' => 11_000,
+        'discount_total' => 0,
+        'total' => 111_000,
+        'payment_method' => 'cash',
+        'amount_paid' => 120_000,
+        'change_due' => 9_000,
+        'notes' => null,
+    ]);
+
+    TransactionItem::query()->create([
+        'transaction_id' => $transaction->id,
+        'product_id' => null,
+        'barcode' => 'ITEM-1',
+        'name' => 'Contoh Produk',
+        'quantity' => 1,
+        'unit_price' => 100_000,
+        'tax_rate' => $settings->ppn_rate,
+        'tax_amount' => 11_000,
+        'line_total' => 111_000,
+    ]);
+
+    $response = $this->actingAs($user)->get(route('transactions.customer', $transaction));
+
+    $logoUrl = Storage::disk('public')->url('branding/logo.png');
+
+    $response->assertInertia(fn (Assert $page) => $page
+        ->component('transactions/customer')
+        ->where('branding.store_name', 'Sunrise Mart')
+        ->where('branding.contact_details', 'Jl. Contoh No. 1, Jakarta')
+        ->where('branding.receipt_footer_text', 'Terima kasih dan sampai jumpa kembali.')
+        ->where('branding.logo_url', $logoUrl)
+    );
+});


### PR DESCRIPTION
## Summary
- extend store settings with branding fields and logo management on the backend and settings form
- surface store branding in employee and customer POS views, including dynamic headers, footers, and printed receipts
- serialize branding data in transaction payloads with new feature coverage and align supplier late delivery metrics with completed orders
