### PR TITLE
Refine customer sync handling in employee transactions

### DIFF
--- a/resources/js/pages/transactions/employee.tsx
+++ b/resources/js/pages/transactions/employee.tsx
@@ -124,6 +124,8 @@ export default function EmployeeTransactions({
         amount_paid: 0,
         notes: '',
     });
+    const { setData } = form;
+    const lastCustomerIdRef = useRef<number | null>(form.data.customer_id ?? null);
 
     const totals = useMemo(() => {
         const subtotal = items.reduce(
@@ -344,8 +346,15 @@ export default function EmployeeTransactions({
     }, [scannerEnabled]);
 
     useEffect(() => {
-        form.setData('customer_id', selectedCustomer ? selectedCustomer.id : null);
-    }, [selectedCustomer, form]);
+        const nextCustomerId = selectedCustomer ? selectedCustomer.id : null;
+
+        if (lastCustomerIdRef.current === nextCustomerId) {
+            return;
+        }
+
+        lastCustomerIdRef.current = nextCustomerId;
+        setData('customer_id', nextCustomerId);
+    }, [selectedCustomer, setData]);
 
     const cleanupScanner = () => {
         readerRef.current?.reset();


### PR DESCRIPTION
## Summary
- extract a stable `setData` reference from the transaction form and cache the last synced customer id
- update the customer synchronization effect to guard against redundant updates and rely on the stable setter

## Testing
- Manual: visited `/transactions/employee`, confirmed the page renders without update depth warnings, and verified selecting and clearing a customer updates the form data

------
https://chatgpt.com/codex/tasks/task_e_68dcdf1a4610832f8f5f27858447bff9