### PR TITLE
Add reusable table controls and apply across dashboards

### DIFF
--- a/resources/js/components/table-controls.tsx
+++ b/resources/js/components/table-controls.tsx
@@ -1,0 +1,176 @@
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Button } from '@/components/ui/button';
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from '@/components/ui/select';
+import { cn } from '@/lib/utils';
+import type { TableFilterOption } from '@/hooks/use-table-controls';
+import { Search } from 'lucide-react';
+import type { TableRange } from '@/hooks/use-table-controls';
+import { useMemo } from 'react';
+
+interface TableToolbarProps {
+    searchTerm: string;
+    onSearchChange: (value: string) => void;
+    searchPlaceholder?: string;
+    filterOptions?: TableFilterOption<unknown>[];
+    filterValue?: string;
+    onFilterChange?: (value: string) => void;
+    pageSize: number;
+    pageSizeOptions: number[];
+    onPageSizeChange: (size: number) => void;
+    total: number;
+    filteredTotal: number;
+    className?: string;
+}
+
+export function TableToolbar({
+    searchTerm,
+    onSearchChange,
+    searchPlaceholder = 'Cari…',
+    filterOptions,
+    filterValue,
+    onFilterChange,
+    pageSize,
+    pageSizeOptions,
+    onPageSizeChange,
+    total,
+    filteredTotal,
+    className,
+}: TableToolbarProps) {
+    const showFilters = (filterOptions?.length ?? 0) > 0;
+    const isFiltered = showFilters && filteredTotal !== total;
+
+    return (
+        <div className={cn('flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between', className)}>
+            <div className="flex flex-1 flex-col gap-2">
+                <Label htmlFor="table-search" className="text-xs font-medium uppercase text-muted-foreground">
+                    Pencarian
+                </Label>
+                <div className="relative">
+                    <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+                    <Input
+                        id="table-search"
+                        value={searchTerm}
+                        onChange={(event) => onSearchChange(event.target.value)}
+                        placeholder={searchPlaceholder}
+                        className="pl-9"
+                    />
+                </div>
+                {isFiltered && (
+                    <p className="text-xs text-muted-foreground">
+                        Menyaring {filteredTotal.toLocaleString('id-ID')} dari {total.toLocaleString('id-ID')} entri.
+                    </p>
+                )}
+            </div>
+
+            <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-end">
+                {showFilters && filterValue != null && onFilterChange && (
+                    <div className="flex flex-col gap-2">
+                        <Label className="text-xs font-medium uppercase text-muted-foreground">Filter</Label>
+                        <Select value={filterValue} onValueChange={onFilterChange}>
+                            <SelectTrigger className="w-56">
+                                <SelectValue placeholder="Pilih filter" />
+                            </SelectTrigger>
+                            <SelectContent>
+                                {filterOptions!.map((option) => (
+                                    <SelectItem key={option.value} value={option.value}>
+                                        {option.label}
+                                    </SelectItem>
+                                ))}
+                            </SelectContent>
+                        </Select>
+                    </div>
+                )}
+
+                <div className="flex flex-col gap-2">
+                    <Label className="text-xs font-medium uppercase text-muted-foreground">Baris per halaman</Label>
+                    <Select
+                        value={String(pageSize)}
+                        onValueChange={(value) => onPageSizeChange(Number.parseInt(value, 10))}
+                    >
+                        <SelectTrigger className="w-32">
+                            <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                            {pageSizeOptions.map((size) => (
+                                <SelectItem key={size} value={String(size)}>
+                                    {size} baris
+                                </SelectItem>
+                            ))}
+                        </SelectContent>
+                    </Select>
+                </div>
+            </div>
+        </div>
+    );
+}
+
+interface TablePaginationProps {
+    page: number;
+    pageCount: number;
+    onPageChange: (page: number) => void;
+    range: TableRange;
+    total: number;
+    filteredTotal: number;
+    className?: string;
+}
+
+export function TablePagination({
+    page,
+    pageCount,
+    onPageChange,
+    range,
+    total,
+    filteredTotal,
+    className,
+}: TablePaginationProps) {
+    const summary = useMemo(() => {
+        if (filteredTotal === 0) {
+            return 'Tidak ada data untuk ditampilkan.';
+        }
+
+        const visibleRange = `${range.start}-${range.end}`;
+        const filteredText = `Menampilkan ${visibleRange} dari ${filteredTotal.toLocaleString('id-ID')} entri`;
+
+        if (filteredTotal === total) {
+            return filteredText;
+        }
+
+        return `${filteredText} (difilter dari ${total.toLocaleString('id-ID')} entri)`;
+    }, [filteredTotal, range.end, range.start, total]);
+
+    return (
+        <div className={cn('flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between', className)}>
+            <p className="text-xs text-muted-foreground">{summary}</p>
+            <div className="flex items-center gap-2">
+                <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={() => onPageChange(page - 1)}
+                    disabled={page <= 1}
+                >
+                    Sebelumnya
+                </Button>
+                <span className="text-xs text-muted-foreground">
+                    Halaman {page} dari {pageCount}
+                </span>
+                <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={() => onPageChange(page + 1)}
+                    disabled={page >= pageCount}
+                >
+                    Berikutnya
+                </Button>
+            </div>
+        </div>
+    );
+}

--- a/resources/js/hooks/use-table-controls.ts
+++ b/resources/js/hooks/use-table-controls.ts
@@ -1,0 +1,176 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+export interface TableFilterOption<T> {
+    label: string;
+    value: string;
+    predicate?: (item: T) => boolean;
+}
+
+export interface UseTableControlsOptions<T> {
+    searchFields?: Array<(item: T) => string | number | null | undefined>;
+    filters?: TableFilterOption<T>[];
+    initialFilter?: string;
+    initialPageSize?: number;
+    pageSizeOptions?: number[];
+}
+
+export interface TableRange {
+    start: number;
+    end: number;
+}
+
+export interface TableControlsResult<T> {
+    searchTerm: string;
+    setSearchTerm: (value: string) => void;
+    filterValue: string;
+    setFilterValue: (value: string) => void;
+    filterOptions: TableFilterOption<T>[];
+    page: number;
+    pageCount: number;
+    pageSize: number;
+    pageSizeOptions: number[];
+    setPageSize: (value: number) => void;
+    goToPage: (page: number) => void;
+    items: T[];
+    total: number;
+    filteredTotal: number;
+    range: TableRange;
+}
+
+const DEFAULT_PAGE_SIZES = [5, 10, 20, 50];
+
+export function useTableControls<T>(
+    data: T[],
+    {
+        searchFields = [],
+        filters = [],
+        initialFilter,
+        initialPageSize = 10,
+        pageSizeOptions = DEFAULT_PAGE_SIZES,
+    }: UseTableControlsOptions<T> = {},
+): TableControlsResult<T> {
+    const [searchTerm, setSearchTerm] = useState('');
+
+    const resolvedInitialFilter = useMemo(() => {
+        if (filters.length === 0) {
+            return 'all';
+        }
+
+        if (initialFilter && filters.some((option) => option.value === initialFilter)) {
+            return initialFilter;
+        }
+
+        return filters[0]?.value ?? 'all';
+    }, [filters, initialFilter]);
+
+    const [filterValue, setFilterValue] = useState(resolvedInitialFilter);
+    const [page, setPage] = useState(1);
+    const [pageSize, setPageSize] = useState(initialPageSize);
+
+    useEffect(() => {
+        setPage(1);
+    }, [searchTerm, filterValue, pageSize]);
+
+    const filtered = useMemo(() => {
+        const normalizedTerm = searchTerm.trim().toLowerCase();
+
+        let next = data;
+
+        if (normalizedTerm.length > 0) {
+            next = next.filter((item) =>
+                searchFields.some((selector) => {
+                    const value = selector(item);
+
+                    if (value == null) {
+                        return false;
+                    }
+
+                    return String(value).toLowerCase().includes(normalizedTerm);
+                }),
+            );
+        }
+
+        if (filters.length > 0) {
+            const activeFilter = filters.find((option) => option.value === filterValue);
+
+            if (activeFilter?.predicate) {
+                next = next.filter((item) => activeFilter.predicate?.(item));
+            }
+        }
+
+        return next;
+    }, [data, filterValue, filters, searchFields, searchTerm]);
+
+    const total = data.length;
+    const filteredTotal = filtered.length;
+
+    const pageCount = Math.max(1, Math.ceil(filteredTotal / pageSize));
+
+    useEffect(() => {
+        setPage((current) => {
+            if (current < 1) {
+                return 1;
+            }
+
+            if (current > pageCount) {
+                return pageCount;
+            }
+
+            return current;
+        });
+    }, [pageCount]);
+
+    const safePage = Math.min(Math.max(page, 1), pageCount);
+
+    const startIndex = filteredTotal === 0 ? 0 : (safePage - 1) * pageSize;
+    const endIndex = filteredTotal === 0 ? 0 : Math.min(startIndex + pageSize, filteredTotal);
+
+    const items = useMemo(() => {
+        if (filteredTotal === 0) {
+            return [];
+        }
+
+        return filtered.slice(startIndex, endIndex);
+    }, [filtered, endIndex, filteredTotal, startIndex]);
+
+    const goToPage = useCallback((nextPage: number) => {
+        setPage((current) => {
+            if (Number.isNaN(nextPage)) {
+                return current;
+            }
+
+            const target = Math.max(1, Math.floor(nextPage));
+
+            if (target > pageCount) {
+                return pageCount;
+            }
+
+            return target;
+        });
+    }, [pageCount]);
+
+    const handlePageSizeChange = useCallback((value: number) => {
+        setPageSize(value);
+    }, []);
+
+    return {
+        searchTerm,
+        setSearchTerm,
+        filterValue,
+        setFilterValue,
+        filterOptions: filters,
+        page: safePage,
+        pageCount,
+        pageSize,
+        pageSizeOptions,
+        setPageSize: handlePageSizeChange,
+        goToPage,
+        items,
+        total,
+        filteredTotal,
+        range: {
+            start: filteredTotal === 0 ? 0 : startIndex + 1,
+            end: filteredTotal === 0 ? 0 : endIndex,
+        },
+    };
+}


### PR DESCRIPTION
## Summary
- add a reusable `useTableControls` hook for client-side search, filtering, and pagination
- introduce shared `TableToolbar` and `TablePagination` components for consistent table controls
- wire the new controls into dashboard, inventory, master data, and transaction tables

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dce20ab140832fa812e9bf7749bae8