### PR TITLE
Add loyalty configuration and redemption workflows

### DIFF
--- a/app/Http/Requests/Transactions/StoreTransactionRequest.php
+++ b/app/Http/Requests/Transactions/StoreTransactionRequest.php
@@ -39,6 +39,9 @@ class StoreTransactionRequest extends FormRequest
             'discount_type' => $this->filled('discount_type') ? $this->input('discount_type') : null,
             'discount_value' => $this->filled('discount_value') ? $this->input('discount_value') : null,
             'notes' => $this->filled('notes') ? $this->input('notes') : null,
+            'loyalty_points_to_redeem' => $this->filled('loyalty_points_to_redeem')
+                ? $this->input('loyalty_points_to_redeem')
+                : null,
         ]);
     }
 
@@ -59,6 +62,7 @@ class StoreTransactionRequest extends FormRequest
             'payment_method' => ['required', 'string', Rule::in(self::PAYMENT_METHODS)],
             'amount_paid' => ['required', 'numeric', 'min:0'],
             'notes' => ['nullable', 'string', 'max:1000'],
+            'loyalty_points_to_redeem' => ['nullable', 'integer', 'min:0'],
         ];
     }
 
@@ -85,6 +89,13 @@ class StoreTransactionRequest extends FormRequest
 
             if ($discountType === 'percentage' && is_numeric($rawDiscountValue) && (float) $rawDiscountValue > 100) {
                 $validator->errors()->add('discount_value', 'Percentage discounts cannot exceed 100%.');
+            }
+
+            $customerId = $this->input('customer_id');
+            $rawRedeem = $this->input('loyalty_points_to_redeem');
+
+            if ($rawRedeem !== null && $rawRedeem !== '' && !$customerId) {
+                $validator->errors()->add('loyalty_points_to_redeem', 'Select a customer before redeeming loyalty points.');
             }
         });
     }

--- a/app/Models/Customer.php
+++ b/app/Models/Customer.php
@@ -35,4 +35,9 @@ class Customer extends Model
     {
         return $this->hasMany(Transaction::class);
     }
+
+    public function loyaltyTransactions(): HasMany
+    {
+        return $this->hasMany(CustomerLoyaltyTransaction::class);
+    }
 }

--- a/app/Models/CustomerLoyaltyTransaction.php
+++ b/app/Models/CustomerLoyaltyTransaction.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class CustomerLoyaltyTransaction extends Model
+{
+    use HasFactory;
+
+    public const TYPE_EARNING = 'earn';
+    public const TYPE_REDEMPTION = 'redeem';
+
+    /**
+     * @var list<string>
+     */
+    protected $fillable = [
+        'customer_id',
+        'transaction_id',
+        'type',
+        'points_change',
+        'points_balance',
+        'amount',
+    ];
+
+    /**
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'amount' => 'float',
+    ];
+
+    public function customer(): BelongsTo
+    {
+        return $this->belongsTo(Customer::class);
+    }
+
+    public function transaction(): BelongsTo
+    {
+        return $this->belongsTo(Transaction::class);
+    }
+}

--- a/app/Services/Loyalty/LoyaltyAdjustment.php
+++ b/app/Services/Loyalty/LoyaltyAdjustment.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Services\Loyalty;
+
+class LoyaltyAdjustment
+{
+    public function __construct(
+        public readonly float $preRedemptionTotal,
+        public readonly float $netTotal,
+        public readonly int $pointsEarned,
+        public readonly int $pointsRedeemed,
+        public readonly float $redemptionValue,
+    ) {
+    }
+
+    public function hasChanges(): bool
+    {
+        return $this->pointsEarned > 0 || $this->pointsRedeemed > 0;
+    }
+}

--- a/app/Services/Loyalty/TransactionLoyaltyService.php
+++ b/app/Services/Loyalty/TransactionLoyaltyService.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace App\Services\Loyalty;
+
+use App\Models\Customer;
+use App\Models\CustomerLoyaltyTransaction;
+use App\Models\Transaction;
+use App\Support\Config\StoreConfig;
+use InvalidArgumentException;
+
+class TransactionLoyaltyService
+{
+    public function preview(?Customer $customer, float $total, ?int $requestedPoints): LoyaltyAdjustment
+    {
+        $preRedemptionTotal = round(max($total, 0), 2);
+
+        if ($customer === null) {
+            return new LoyaltyAdjustment($preRedemptionTotal, $preRedemptionTotal, 0, 0, 0.0);
+        }
+
+        $pointsPerCurrency = StoreConfig::loyaltyPointsPerCurrency();
+        $currencyPerPoint = StoreConfig::loyaltyCurrencyPerPoint();
+        $minimumRedeemable = StoreConfig::loyaltyMinimumRedeemablePoints();
+        $availablePoints = max((int) $customer->loyalty_points, 0);
+        $requested = max((int) ($requestedPoints ?? 0), 0);
+
+        $pointsToRedeem = 0;
+        $redemptionValue = 0.0;
+
+        if ($requested > 0 && $currencyPerPoint > 0 && $availablePoints > 0) {
+            $pointsToRedeem = min($requested, $availablePoints);
+            $maxRedeemableByValue = (int) floor($preRedemptionTotal / $currencyPerPoint);
+            if ($maxRedeemableByValue > 0) {
+                $pointsToRedeem = min($pointsToRedeem, $maxRedeemableByValue);
+            }
+
+            if ($pointsToRedeem < $minimumRedeemable) {
+                $pointsToRedeem = 0;
+            }
+
+            if ($pointsToRedeem > 0) {
+                $redemptionValue = round($pointsToRedeem * $currencyPerPoint, 2);
+                $redemptionValue = min($redemptionValue, $preRedemptionTotal);
+            }
+        }
+
+        $netTotal = round(max($preRedemptionTotal - $redemptionValue, 0), 2);
+        $pointsEarned = 0;
+
+        if ($pointsPerCurrency > 0) {
+            $rawPoints = $netTotal * $pointsPerCurrency;
+            $pointsEarned = $this->roundPoints($rawPoints);
+        }
+
+        return new LoyaltyAdjustment(
+            $preRedemptionTotal,
+            $netTotal,
+            $pointsEarned,
+            $pointsToRedeem,
+            $redemptionValue,
+        );
+    }
+
+    public function finalize(?Customer $customer, Transaction $transaction, LoyaltyAdjustment $adjustment): void
+    {
+        if ($customer === null || $transaction->customer_id === null || !$adjustment->hasChanges()) {
+            return;
+        }
+
+        $balance = (int) $customer->loyalty_points;
+
+        if ($adjustment->pointsRedeemed > 0) {
+            if ($balance < $adjustment->pointsRedeemed) {
+                throw new InvalidArgumentException('Customer does not have enough loyalty points to redeem.');
+            }
+
+            $balance -= $adjustment->pointsRedeemed;
+
+            CustomerLoyaltyTransaction::query()->create([
+                'customer_id' => $customer->id,
+                'transaction_id' => $transaction->id,
+                'type' => CustomerLoyaltyTransaction::TYPE_REDEMPTION,
+                'points_change' => -$adjustment->pointsRedeemed,
+                'points_balance' => $balance,
+                'amount' => $adjustment->redemptionValue,
+            ]);
+        }
+
+        if ($adjustment->pointsEarned > 0) {
+            $balance += $adjustment->pointsEarned;
+
+            CustomerLoyaltyTransaction::query()->create([
+                'customer_id' => $customer->id,
+                'transaction_id' => $transaction->id,
+                'type' => CustomerLoyaltyTransaction::TYPE_EARNING,
+                'points_change' => $adjustment->pointsEarned,
+                'points_balance' => $balance,
+                'amount' => $adjustment->netTotal,
+            ]);
+        }
+
+        $customer->loyalty_points = $balance;
+        $customer->save();
+    }
+
+    private function roundPoints(float $value): int
+    {
+        return match (StoreConfig::loyaltyEarningRounding()) {
+            'up' => (int) ceil($value),
+            'nearest' => (int) round($value, 0, PHP_ROUND_HALF_UP),
+            default => (int) floor($value),
+        };
+    }
+}

--- a/app/Support/Config/StoreConfig.php
+++ b/app/Support/Config/StoreConfig.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Support\Config;
+
+use Illuminate\Support\Arr;
+
+class StoreConfig
+{
+    /**
+     * Retrieve the configured loyalty settings array.
+     *
+     * @return array<string, mixed>
+     */
+    public static function loyalty(): array
+    {
+        return config('store.loyalty', []);
+    }
+
+    public static function loyaltyPointsPerCurrency(): float
+    {
+        return (float) Arr::get(self::loyalty(), 'points_per_currency', 0.0);
+    }
+
+    public static function loyaltyCurrencyPerPoint(): float
+    {
+        return (float) Arr::get(self::loyalty(), 'currency_per_point', 0.0);
+    }
+
+    public static function loyaltyMinimumRedeemablePoints(): int
+    {
+        return (int) Arr::get(self::loyalty(), 'minimum_redeemable_points', 0);
+    }
+
+    public static function loyaltyEarningRounding(): string
+    {
+        $mode = (string) Arr::get(self::loyalty(), 'earning_rounding', 'down');
+
+        return match ($mode) {
+            'down', 'nearest', 'up' => $mode,
+            default => 'down',
+        };
+    }
+}

--- a/config/store.php
+++ b/config/store.php
@@ -11,4 +11,10 @@ return [
         'notification_roles' => ['Administrator'],
         'notification_channels' => ['mail', 'database'],
     ],
+    'loyalty' => [
+        'points_per_currency' => 1,
+        'currency_per_point' => 0.01,
+        'minimum_redeemable_points' => 100,
+        'earning_rounding' => 'down', // down|nearest|up
+    ],
 ];

--- a/database/migrations/2024_01_01_000001_create_customer_loyalty_transactions_table.php
+++ b/database/migrations/2024_01_01_000001_create_customer_loyalty_transactions_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('customer_loyalty_transactions', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('customer_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('transaction_id')->nullable()->constrained()->nullOnDelete();
+            $table->string('type');
+            $table->integer('points_change');
+            $table->integer('points_balance');
+            $table->decimal('amount', 12, 2)->default(0);
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('customer_loyalty_transactions');
+    }
+};

--- a/resources/js/pages/transactions/customer.tsx
+++ b/resources/js/pages/transactions/customer.tsx
@@ -45,9 +45,19 @@ interface TransactionSummary {
               phone: string | null;
               loyalty_number: string | null;
               loyalty_points: number;
+              loyalty_history: LoyaltyHistoryEntry[];
           }
         | null;
     items: TransactionItemSummary[];
+}
+
+interface LoyaltyHistoryEntry {
+    id: number;
+    type: 'earn' | 'redeem';
+    points_change: number;
+    points_balance: number;
+    amount: number;
+    created_at: string | null;
 }
 
 interface BrandingInfo {
@@ -103,6 +113,10 @@ export default function CustomerDisplay({
         bank_transfer: 'Transfer bank',
         e_wallet: 'Dompet digital',
         other: 'Lainnya',
+    };
+    const loyaltyTypeLabels: Record<LoyaltyHistoryEntry['type'], string> = {
+        earn: 'Poin diterima',
+        redeem: 'Poin digunakan',
     };
 
     const formatCurrency = (value: number) => currencyFormatter.format(value);
@@ -460,6 +474,60 @@ export default function CustomerDisplay({
                                         </dd>
                                     </div>
                                 </dl>
+                                <div className="mt-6 space-y-3">
+                                    <h4 className="text-xl font-semibold">Riwayat loyalti terbaru</h4>
+                                    {transaction.customer.loyalty_history.length === 0 ? (
+                                        <p className="text-sm text-muted-foreground">
+                                            Belum ada aktivitas loyalti untuk pelanggan ini.
+                                        </p>
+                                    ) : (
+                                        <div className="overflow-hidden rounded-lg border border-border">
+                                            <table className="min-w-full divide-y divide-border text-sm">
+                                                <thead className="bg-muted/50">
+                                                    <tr>
+                                                        <th className="px-4 py-3 text-left font-medium">Tanggal</th>
+                                                        <th className="px-4 py-3 text-left font-medium">Aktivitas</th>
+                                                        <th className="px-4 py-3 text-right font-medium">Perubahan poin</th>
+                                                        <th className="px-4 py-3 text-right font-medium">Saldo</th>
+                                                        <th className="px-4 py-3 text-right font-medium">Nominal</th>
+                                                    </tr>
+                                                </thead>
+                                                <tbody className="divide-y divide-border">
+                                                    {transaction.customer.loyalty_history.map((entry) => {
+                                                        const formattedChange = `${entry.points_change > 0 ? '+' : ''}${entry.points_change.toLocaleString(numberLocale)}`;
+
+                                                        return (
+                                                            <tr key={entry.id}>
+                                                                <td className="px-4 py-3">
+                                                                    {entry.created_at ? formatDate(entry.created_at) : '-'}
+                                                                </td>
+                                                                <td className="px-4 py-3">
+                                                                    {loyaltyTypeLabels[entry.type]}
+                                                                </td>
+                                                                <td
+                                                                    className={cn(
+                                                                        'px-4 py-3 text-right font-medium',
+                                                                        entry.points_change < 0
+                                                                            ? 'text-destructive'
+                                                                            : 'text-emerald-600 dark:text-emerald-400',
+                                                                    )}
+                                                                >
+                                                                    {formattedChange}
+                                                                </td>
+                                                                <td className="px-4 py-3 text-right">
+                                                                    {entry.points_balance.toLocaleString(numberLocale)}
+                                                                </td>
+                                                                <td className="px-4 py-3 text-right">
+                                                                    {formatCurrency(entry.amount)}
+                                                                </td>
+                                                            </tr>
+                                                        );
+                                                    })}
+                                                </tbody>
+                                            </table>
+                                        </div>
+                                    )}
+                                </div>
                             </div>
                         )}
                     </div>

--- a/tests/Feature/Transactions/TransactionLoyaltyTest.php
+++ b/tests/Feature/Transactions/TransactionLoyaltyTest.php
@@ -1,0 +1,191 @@
+<?php
+
+use App\Models\Customer;
+use App\Models\CustomerLoyaltyTransaction;
+use App\Models\Product;
+use App\Models\Transaction;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function (): void {
+    $this->withoutVite();
+});
+
+function createTestProduct(array $attributes = []): Product
+{
+    return Product::query()->create(array_merge([
+        'barcode' => 'LOY-' . Str::upper(Str::random(8)),
+        'name' => 'Loyalty Product',
+        'stock' => 50,
+        'price' => 50.0,
+    ], $attributes));
+}
+
+function assertLoyaltyConfig(array $overrides = []): void
+{
+    config()->set('store.loyalty', array_merge([
+        'points_per_currency' => 1.0,
+        'currency_per_point' => 0.1,
+        'minimum_redeemable_points' => 100,
+        'earning_rounding' => 'down',
+    ], $overrides));
+}
+
+it('awards loyalty points and records audit entries', function () {
+    assertLoyaltyConfig([
+        'points_per_currency' => 1.0,
+        'currency_per_point' => 0.1,
+        'minimum_redeemable_points' => 50,
+        'earning_rounding' => 'down',
+    ]);
+
+    $user = User::factory()->create();
+    $customer = Customer::factory()->create(['loyalty_points' => 0]);
+    $product = createTestProduct(['price' => 100, 'stock' => 10]);
+
+    $response = $this->actingAs($user)->post(route('transactions.store'), [
+        'items' => [
+            ['product_id' => $product->id, 'quantity' => 1],
+        ],
+        'customer_id' => $customer->id,
+        'payment_method' => 'cash',
+        'amount_paid' => 150,
+    ]);
+
+    $response->assertRedirect(route('transactions.employee'));
+
+    $customer->refresh();
+    $transaction = Transaction::query()->latest()->first();
+
+    expect($transaction)->not->toBeNull();
+    expect($customer->loyalty_points)->toBe(111);
+
+    $entries = CustomerLoyaltyTransaction::query()
+        ->where('customer_id', $customer->id)
+        ->get();
+
+    expect($entries)->toHaveCount(1)
+        ->and($entries->first()->type)->toBe(CustomerLoyaltyTransaction::TYPE_EARNING)
+        ->and($entries->first()->points_change)->toBe(111)
+        ->and($entries->first()->points_balance)->toBe(111)
+        ->and((float) $transaction->total)->toBe(111.0);
+});
+
+it('enforces minimum redemption and available balance limits', function () {
+    assertLoyaltyConfig([
+        'points_per_currency' => 1.0,
+        'currency_per_point' => 0.1,
+        'minimum_redeemable_points' => 100,
+        'earning_rounding' => 'down',
+    ]);
+
+    $user = User::factory()->create();
+    $product = createTestProduct();
+
+    $minCustomer = Customer::factory()->create(['loyalty_points' => 90]);
+    $capCustomer = Customer::factory()->create(['loyalty_points' => 180]);
+
+    $this->actingAs($user)->post(route('transactions.store'), [
+        'items' => [
+            ['product_id' => $product->id, 'quantity' => 1],
+        ],
+        'customer_id' => $minCustomer->id,
+        'loyalty_points_to_redeem' => 80,
+        'payment_method' => 'card',
+        'amount_paid' => 100,
+    ])->assertRedirect(route('transactions.employee'));
+
+    $minCustomer->refresh();
+    $minTransaction = Transaction::query()
+        ->where('customer_id', $minCustomer->id)
+        ->latest()
+        ->first();
+
+    expect($minTransaction)->not->toBeNull();
+    expect($minCustomer->loyalty_points)->toBe(145);
+
+    $minEntries = CustomerLoyaltyTransaction::query()
+        ->where('customer_id', $minCustomer->id)
+        ->get();
+
+    expect($minEntries)->toHaveCount(1)
+        ->and($minEntries->first()->type)->toBe(CustomerLoyaltyTransaction::TYPE_EARNING)
+        ->and($minEntries->first()->points_change)->toBe(55)
+        ->and((float) $minTransaction->total)->toBe(55.5);
+
+    $this->actingAs($user)->post(route('transactions.store'), [
+        'items' => [
+            ['product_id' => $product->id, 'quantity' => 1],
+        ],
+        'customer_id' => $capCustomer->id,
+        'loyalty_points_to_redeem' => 300,
+        'payment_method' => 'cash',
+        'amount_paid' => 50,
+    ])->assertRedirect(route('transactions.employee'));
+
+    $capCustomer->refresh();
+    $capTransaction = Transaction::query()
+        ->where('customer_id', $capCustomer->id)
+        ->latest()
+        ->first();
+
+    expect($capTransaction)->not->toBeNull();
+    expect((float) $capTransaction?->total)->toBe(37.5);
+    expect($capCustomer->loyalty_points)->toBe(37);
+
+    $capEntries = CustomerLoyaltyTransaction::query()
+        ->where('customer_id', $capCustomer->id)
+        ->orderBy('id')
+        ->get();
+
+    expect($capEntries)->toHaveCount(2)
+        ->and($capEntries->first()->type)->toBe(CustomerLoyaltyTransaction::TYPE_REDEMPTION)
+        ->and($capEntries->first()->points_change)->toBe(-180)
+        ->and($capEntries->first()->points_balance)->toBe(0)
+        ->and((float) $capEntries->first()->amount)->toBe(18.0)
+        ->and($capEntries->last()->type)->toBe(CustomerLoyaltyTransaction::TYPE_EARNING)
+        ->and($capEntries->last()->points_change)->toBe(37)
+        ->and($capEntries->last()->points_balance)->toBe(37);
+});
+
+it('rounds earned points according to configuration', function () {
+    assertLoyaltyConfig([
+        'points_per_currency' => 0.1,
+        'currency_per_point' => 0.01,
+        'minimum_redeemable_points' => 10,
+        'earning_rounding' => 'nearest',
+    ]);
+
+    $user = User::factory()->create();
+    $customer = Customer::factory()->create(['loyalty_points' => 0]);
+    $product = createTestProduct(['stock' => 5]);
+
+    $this->actingAs($user)->post(route('transactions.store'), [
+        'items' => [
+            ['product_id' => $product->id, 'quantity' => 1],
+        ],
+        'customer_id' => $customer->id,
+        'payment_method' => 'cash',
+        'amount_paid' => 100,
+    ])->assertRedirect(route('transactions.employee'));
+
+    $customer->refresh();
+    $transaction = Transaction::query()
+        ->where('customer_id', $customer->id)
+        ->latest()
+        ->first();
+
+    expect($transaction)->not->toBeNull();
+    expect((float) $transaction?->total)->toBe(55.5);
+    expect($customer->loyalty_points)->toBe(6);
+
+    $entry = CustomerLoyaltyTransaction::query()
+        ->where('customer_id', $customer->id)
+        ->first();
+
+    expect($entry)->not->toBeNull()
+        ->and($entry?->points_change)->toBe(6);
+});


### PR DESCRIPTION
## Summary
- add loyalty configuration helper, service layer, and persistence model to manage point accrual and redemption during transactions
- surface loyalty balances, redemption inputs, and audit history across the employee checkout and customer display UIs
- cover earning, redemption thresholds, and rounding behaviour with new feature tests